### PR TITLE
[agent-task] Add Markdown/MDX content model for projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,10 @@ Start the production server after a build:
 ```powershell
 npm run start
 ```
+
+## Project Content
+
+Project entries live in `content/projects/` as Markdown files with frontmatter.
+
+Each project entry should define metadata such as title, slug, status, summary,
+stack, next milestone, and public-safe repository or docs URLs.

--- a/app/globals.css
+++ b/app/globals.css
@@ -102,6 +102,36 @@ h1 {
   color: var(--muted);
 }
 
+.project-list {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.project-card {
+  display: grid;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.project-card h2,
+.project-card p {
+  margin: 0;
+}
+
+.project-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
 @media (max-width: 640px) {
   .site-header {
     align-items: flex-start;

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,12 +1,28 @@
-export default function ProjectsPage() {
+import { getProjectEntries } from '@/lib/content/projects';
+
+export default async function ProjectsPage() {
+  const projects = await getProjectEntries();
+
   return (
     <section className="stack">
       <p className="eyebrow">Projects</p>
-      <h1>Project index placeholder</h1>
+      <h1>Project content foundation</h1>
       <p className="lede">
-        Detailed project entries will arrive in a later issue once the content
-        model is in place.
+        Project entries now load from Markdown frontmatter. A later issue will
+        turn this data into the full project index and detail UI.
       </p>
+      <ul className="project-list">
+        {projects.map((project) => (
+          <li className="project-card" key={project.slug}>
+            <h2>{project.title}</h2>
+            <p>{project.summary}</p>
+            <p className="project-meta">
+              <span>{project.status}</span>
+              <span>{project.stack.join(' · ')}</span>
+            </p>
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/content/projects/personal-site.md
+++ b/content/projects/personal-site.md
@@ -1,0 +1,17 @@
+---
+title: Personal Site
+slug: personal-site
+status: planning
+summary: Static-first site for organizing projects, notes, and deployment writeups.
+stack:
+  - Next.js
+  - TypeScript
+  - Markdown
+next_milestone: Add the project content model and initial project pages.
+repo_url: https://github.com/jjmgoss/personal-site
+live_url:
+docs_url: https://github.com/jjmgoss/personal-site/tree/main/docs
+---
+
+This repository is the public project hub for ongoing software experiments,
+documentation, and implementation notes.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -44,7 +44,7 @@ Acceptance criteria:
 
 Goal: create the smallest working Next.js site.
 
-Status: in progress.
+Status: complete.
 
 Tasks:
 
@@ -71,6 +71,8 @@ Acceptance criteria:
 ## Phase 2: Content Model
 
 Goal: make projects and writing pages content-driven.
+
+Status: in progress.
 
 Tasks:
 

--- a/lib/content/projects.ts
+++ b/lib/content/projects.ts
@@ -1,0 +1,121 @@
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+
+const PROJECT_STATUSES = [
+  'idea',
+  'planning',
+  'active',
+  'paused',
+  'shipped',
+  'archived',
+] as const;
+
+export type ProjectStatus = (typeof PROJECT_STATUSES)[number];
+
+export type ProjectMetadata = {
+  title: string;
+  slug: string;
+  status: ProjectStatus;
+  summary: string;
+  stack: string[];
+  next_milestone: string;
+  repo_url: string;
+  live_url?: string;
+  docs_url?: string;
+};
+
+export type ProjectEntry = ProjectMetadata & {
+  content: string;
+};
+
+const projectsDirectory = path.join(process.cwd(), 'content', 'projects');
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function requireStringField(data: Record<string, unknown>, field: string, filePath: string): string {
+  const value = data[field];
+
+  if (!isNonEmptyString(value)) {
+    throw new Error(`Invalid project frontmatter in ${filePath}: "${field}" is required.`);
+  }
+
+  return value.trim();
+}
+
+function isOptionalUrl(value: unknown): value is string | undefined {
+  return value === undefined || value === null || isNonEmptyString(value);
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  return isNonEmptyString(value) ? value.trim() : undefined;
+}
+
+function parseProjectMetadata(filePath: string, data: Record<string, unknown>): ProjectMetadata {
+  const title = requireStringField(data, 'title', filePath);
+  const slug = requireStringField(data, 'slug', filePath);
+  const summary = requireStringField(data, 'summary', filePath);
+  const nextMilestone = requireStringField(data, 'next_milestone', filePath);
+  const repoUrl = requireStringField(data, 'repo_url', filePath);
+
+  if (!PROJECT_STATUSES.includes(data.status as ProjectStatus)) {
+    throw new Error(
+      `Invalid project frontmatter in ${filePath}: "status" must be one of ${PROJECT_STATUSES.join(', ')}.`
+    );
+  }
+
+  if (!Array.isArray(data.stack) || data.stack.length === 0 || data.stack.some((item) => !isNonEmptyString(item))) {
+    throw new Error(`Invalid project frontmatter in ${filePath}: "stack" must be a non-empty list of strings.`);
+  }
+
+  if (!isOptionalUrl(data.live_url)) {
+    throw new Error(`Invalid project frontmatter in ${filePath}: "live_url" must be a string when provided.`);
+  }
+
+  if (!isOptionalUrl(data.docs_url)) {
+    throw new Error(`Invalid project frontmatter in ${filePath}: "docs_url" must be a string when provided.`);
+  }
+
+  return {
+    title,
+    slug,
+    status: data.status as ProjectStatus,
+    summary,
+    stack: data.stack.map((item) => item.trim()),
+    next_milestone: nextMilestone,
+    repo_url: repoUrl,
+    live_url: toOptionalString(data.live_url),
+    docs_url: toOptionalString(data.docs_url),
+  };
+}
+
+export async function getProjectEntries(): Promise<ProjectEntry[]> {
+  const fileNames = await readdir(projectsDirectory);
+  const projectFiles = fileNames.filter((fileName) => fileName.endsWith('.md') || fileName.endsWith('.mdx'));
+
+  const projects = await Promise.all(
+    projectFiles.map(async (fileName) => {
+      const filePath = path.join(projectsDirectory, fileName);
+      const rawFile = await readFile(filePath, 'utf8');
+      const { data, content } = matter(rawFile);
+      const metadata = parseProjectMetadata(fileName, data);
+
+      return {
+        ...metadata,
+        content: content.trim(),
+      };
+    })
+  );
+
+  const slugs = new Set<string>();
+  for (const project of projects) {
+    if (slugs.has(project.slug)) {
+      throw new Error(`Duplicate project slug detected: "${project.slug}".`);
+    }
+    slugs.add(project.slug);
+  }
+
+  return projects.sort((left, right) => left.title.localeCompare(right.title));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "personal-site",
       "version": "0.1.0",
       "dependencies": {
+        "gray-matter": "^4.0.3",
         "next": "^15.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -728,6 +729,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001791",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
@@ -769,6 +779,77 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/nanoid": {
@@ -902,6 +983,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -965,6 +1059,21 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "gray-matter": "^4.0.3",
     "next": "^15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"


### PR DESCRIPTION
## Summary

Add a static-first Markdown project content model with typed frontmatter parsing and build-time validation.

## Linked Issue Or Reference

Closes #4

## What Changed

- Added a `content/projects/` directory with a sample `personal-site` Markdown entry
- Added a typed project metadata shape and Markdown loader in `lib/content/projects.ts`
- Added clear build-time validation for required frontmatter fields, allowed status values, and duplicate slugs
- Updated `/projects` to load project content from files so invalid content fails during `next build`
- Documented where project content lives and marked the implementation plan's content-model phase as in progress
- Added the small `gray-matter` dependency needed for frontmatter parsing

## Verification

```text
npm install
- succeeded; installed the new frontmatter parser dependency

npm run build
- succeeded; Next.js statically built /, /projects, and /writing after validating project content

git diff --stat
- showed changes to the projects page, loader, README, implementation plan, package files, and new content/model files

git status
- showed the issue branch changes before staging and commit
```

## Risk And Deployment Impact

Low-risk content-foundation change only. No database, CMS, auth, Docker, deployment automation, or private infrastructure values added.

## Reviewer Focus

- Confirm the frontmatter schema fields and validation rules are the right minimum set for project content
- Confirm using the `/projects` route to force build-time validation is the right temporary integration point before issue #5
- Confirm the sample content stays public-safe and does not imply nonexistent live URLs

## Follow-Ups

- Build the actual project index UI in issue #5
- Add more project entries once the detail/index pages are ready
- Add the writing content model in a separate issue