### PR TITLE
[agent-task] Add initial project content

### DIFF
--- a/content/projects/hn-trend-tracker.md
+++ b/content/projects/hn-trend-tracker.md
@@ -1,0 +1,34 @@
+---
+title: HN Trend Tracker
+slug: hn-trend-tracker
+status: active
+summary: Hacker News data pipeline and read-only app for tracking stories, score changes, comment changes, and trend-oriented analytics over time.
+stack:
+  - Python
+  - Next.js
+  - SQLAlchemy
+  - Postgres
+  - Plotly
+  - Docker
+  - dbt
+next_milestone: Add richer trend views and continue improving the historical analytics pipeline.
+repo_url: https://github.com/jjmgoss/hn-trend-tracker
+live_url:
+docs_url: https://github.com/jjmgoss/hn-trend-tracker/tree/main/docs
+---
+
+`hn-trend-tracker` is a Hacker News data project focused on collecting useful
+story history and turning it into a read-only analysis surface.
+
+Today the project combines a Python backend and ingestion pipeline with a
+Next.js frontend. It stores the latest known state for items and users, appends
+historical story observations during refresh cycles, and uses supporting docs and
+analytics models to make the system easier to extend.
+
+The project is intentionally practical rather than overbuilt. It is aimed at
+capturing enough structured data to answer questions about story momentum,
+comment growth, repost patterns, and broader trend behavior without adding
+unnecessary product complexity.
+
+No public live deployment is linked here yet because this site should only point
+to real public URLs when they actually exist.

--- a/content/projects/personal-site.md
+++ b/content/projects/personal-site.md
@@ -1,17 +1,31 @@
 ---
 title: Personal Site
 slug: personal-site
-status: planning
-summary: Static-first site for organizing projects, notes, and deployment writeups.
+status: active
+summary: Static-first project hub for side projects, documentation, writing, deployment notes, and links to live demos.
 stack:
   - Next.js
   - TypeScript
   - Markdown
-next_milestone: Add the project content model and initial project pages.
+  - GitHub Issues
+next_milestone: Expand project content and add the first writing and log pages.
 repo_url: https://github.com/jjmgoss/personal-site
 live_url:
 docs_url: https://github.com/jjmgoss/personal-site/tree/main/docs
 ---
 
-This repository is the public project hub for ongoing software experiments,
-documentation, and implementation notes.
+`personal-site` is the public home base for the projects in this workspace.
+
+The site is meant to stay static-first and content-oriented. Instead of pulling
+project data from a database or CMS, it generates pages from files that are easy
+to review in pull requests and easy for coding agents to update safely.
+
+The initial scope is intentionally narrow:
+
+- a homepage that explains the project lab
+- a project catalog with detail pages
+- a writing/log section for implementation notes
+- public-safe deployment notes and links to live demos when they exist
+
+The current milestone is to make the project catalog feel real with useful
+entries and then extend the same content-driven pattern to the writing section.

--- a/content/projects/repo-rails.md
+++ b/content/projects/repo-rails.md
@@ -1,0 +1,30 @@
+---
+title: repo-rails
+slug: repo-rails
+status: active
+summary: Reusable setup and compliance toolkit for agent-friendly GitHub repositories using issue-driven, PR-first workflows.
+stack:
+  - Python
+  - uv
+  - GitHub CLI
+  - GitHub Actions
+  - Repository templates
+next_milestone: Expand reusable profiles and continue tightening setup and compliance checks for target repositories.
+repo_url: https://github.com/jjmgoss/repo-rails
+live_url:
+docs_url: https://github.com/jjmgoss/repo-rails/tree/main/docs
+---
+
+`repo-rails` packages the scaffolding, checks, and safety defaults needed to set
+up repositories for coding-agent workflows without relying on ad hoc manual
+steps.
+
+The toolkit is designed around issue-driven development, setup branches, pull
+requests, and explicit verification. It helps create a consistent repository
+surface for instructions, templates, managed workflow files, and compliance
+checks while keeping target repositories in control of their own project-specific
+context.
+
+The current implementation centers on a Python CLI, with reusable profiles and
+templates that support agent-friendly repository setup for projects like this
+one.


### PR DESCRIPTION
## Summary

Add the first public-safe project entries for `personal-site`, `hn-trend-tracker`, and `repo-rails` so the project catalog feels real without changing the content schema or app features.

## Linked Issue Or Reference

Closes #6

## What Changed

- Updated `content/projects/personal-site.md` with fuller public-facing content, an `active` status, a broader stack list, and a more current next milestone
- Added `content/projects/hn-trend-tracker.md` with public-safe metadata, docs/repo links, and a body describing the current architecture and scope
- Added `content/projects/repo-rails.md` with public-safe metadata, docs/repo links, and a body describing the toolkit's purpose and current implementation direction
- Kept all links limited to real GitHub repository and docs URLs, with no invented live deployments

## Verification

```text
npm install
- succeeded; dependencies were already up to date

npm run build
- succeeded; static generation now includes /projects/personal-site, /projects/hn-trend-tracker, and /projects/repo-rails

git diff --stat
- showed the tracked update to content/projects/personal-site.md before commit
- note: the two new content files were still untracked at that moment, so plain diff --stat did not list them yet

git status
- showed one modified content file and two new content files before staging and commit

Manual local verification
- /projects rendered all three project cards
- /projects/personal-site rendered the updated content
- /projects/hn-trend-tracker rendered the new content
- /projects/repo-rails rendered the new content
```

## Risk And Deployment Impact

Content-only change. No schema changes, app feature changes, deployment changes, private infrastructure details, or invented live URLs were added.

## Reviewer Focus

- Confirm the three project entries feel accurate and public-safe
- Confirm the statuses, stacks, and next milestones reflect the current state of each project well enough for an initial catalog
- Confirm the linked repo/docs URLs are the right public surfaces for each project

## Follow-Ups

- Add more projects only when their summaries and public-safe links are ready
- Revisit project statuses and milestones as the underlying repositories evolve
- Expand the writing/log section in separate issues