### PR TITLE
[agent-task] Build writing/log section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,10 @@ Project entries live in `content/projects/` as Markdown files with frontmatter.
 
 Each project entry should define metadata such as title, slug, status, summary,
 stack, next milestone, and public-safe repository or docs URLs.
+
+## Writing Content
+
+Writing and log posts live in `content/writing/` as Markdown files with frontmatter.
+
+Each post should define metadata such as title, slug, date, summary, tags, and
+related projects.

--- a/app/globals.css
+++ b/app/globals.css
@@ -222,6 +222,74 @@ h1 {
   text-decoration: underline;
 }
 
+.post-list {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.post-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.post-card h2,
+.post-card p {
+  margin: 0;
+}
+
+.post-card h2 {
+  font-size: 1.5rem;
+}
+
+.post-date {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tag-pill {
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(31, 41, 55, 0.08);
+  color: var(--foreground);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.post-meta {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.post-meta a {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.writing-detail {
+  gap: 1.5rem;
+}
+
 @media (max-width: 640px) {
   .site-header {
     align-items: flex-start;

--- a/app/writing/[slug]/page.tsx
+++ b/app/writing/[slug]/page.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import ReactMarkdown from 'react-markdown';
+import { getWritingEntry, getWritingSlugs } from '@/lib/content/writing';
+
+type WritingDetailPageProps = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export async function generateStaticParams() {
+  const slugs = await getWritingSlugs();
+  return slugs.map((slug) => ({ slug }));
+}
+
+export default async function WritingDetailPage({ params }: WritingDetailPageProps) {
+  const { slug } = await params;
+  const entry = await getWritingEntry(slug);
+
+  if (!entry) {
+    notFound();
+  }
+
+  return (
+    <article className="stack writing-detail">
+      <Link className="back-link" href="/writing">
+        Back to writing
+      </Link>
+      <p className="eyebrow">Writing</p>
+      <div className="stack-tight">
+        <p className="post-date">{entry.date}</p>
+        <h1>{entry.title}</h1>
+      </div>
+      <p className="lede">{entry.summary}</p>
+      <ul className="tag-list">
+        {entry.tags.map((tag) => (
+          <li className="tag-pill" key={tag}>
+            {tag}
+          </li>
+        ))}
+      </ul>
+      {entry.related_projects.length > 0 ? (
+        <p className="post-meta">
+          Related projects:{' '}
+          {entry.related_projects.map((projectSlug, index) => (
+            <span key={projectSlug}>
+              {index > 0 ? ', ' : ''}
+              <Link href={`/projects/${projectSlug}`}>{projectSlug}</Link>
+            </span>
+          ))}
+        </p>
+      ) : null}
+      <div className="markdown-body">
+        <ReactMarkdown>{entry.content}</ReactMarkdown>
+      </div>
+    </article>
+  );
+}

--- a/app/writing/page.tsx
+++ b/app/writing/page.tsx
@@ -1,12 +1,48 @@
-export default function WritingPage() {
+import Link from 'next/link';
+import { getWritingEntries } from '@/lib/content/writing';
+
+export default async function WritingPage() {
+  const entries = await getWritingEntries();
+
   return (
     <section className="stack">
       <p className="eyebrow">Writing</p>
-      <h1>Writing and log placeholder</h1>
+      <h1>Implementation notes and project log</h1>
       <p className="lede">
-        This section will hold implementation notes, project updates, and
-        longer-form writeups in a future issue.
+        Writing posts are generated from Markdown files so implementation notes,
+        project updates, and longer-form writeups stay reviewable and static-first.
       </p>
+      <ul className="post-list">
+        {entries.map((entry) => (
+          <li className="post-card" key={entry.slug}>
+            <div className="stack-tight">
+              <p className="post-date">{entry.date}</p>
+              <h2>
+                <Link href={`/writing/${entry.slug}`}>{entry.title}</Link>
+              </h2>
+            </div>
+            <p>{entry.summary}</p>
+            <ul className="tag-list">
+              {entry.tags.map((tag) => (
+                <li className="tag-pill" key={tag}>
+                  {tag}
+                </li>
+              ))}
+            </ul>
+            {entry.related_projects.length > 0 ? (
+              <p className="post-meta">
+                Related projects:{' '}
+                {entry.related_projects.map((projectSlug, index) => (
+                  <span key={projectSlug}>
+                    {index > 0 ? ', ' : ''}
+                    <Link href={`/projects/${projectSlug}`}>{projectSlug}</Link>
+                  </span>
+                ))}
+              </p>
+            ) : null}
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/content/writing/building-the-personal-site.md
+++ b/content/writing/building-the-personal-site.md
@@ -1,0 +1,30 @@
+---
+title: Building the Personal Site
+slug: building-the-personal-site
+date: 2026-05-03
+summary: Notes on building this site as a static-first project hub with Next.js, Markdown content, GitHub issues, and small agent-executed pull requests.
+tags:
+  - site-building
+  - nextjs
+  - markdown
+  - agent-workflow
+related_projects:
+  - personal-site
+---
+
+This site is being built as a static-first project hub rather than a heavy web
+application with a database or CMS.
+
+The goal is to keep the content easy to review, easy to update in pull requests,
+and easy to evolve one issue at a time. Project entries and writing posts live
+in Markdown files so the site can be generated from the repository itself.
+
+The implementation approach is intentionally small and incremental:
+
+- use Next.js App Router with TypeScript
+- store content in Markdown with frontmatter
+- plan work in GitHub issues
+- ship changes as focused, agent-executed pull requests
+
+That approach keeps the site public-safe and maintainable while it grows into a
+better catalog of projects, notes, and deployment writeups.

--- a/lib/content/writing.ts
+++ b/lib/content/writing.ts
@@ -1,0 +1,129 @@
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+import { getProjectSlugs } from '@/lib/content/projects';
+
+export type WritingMetadata = {
+  title: string;
+  slug: string;
+  date: string;
+  summary: string;
+  tags: string[];
+  related_projects: string[];
+};
+
+export type WritingEntry = WritingMetadata & {
+  content: string;
+};
+
+const writingDirectory = path.join(process.cwd(), 'content', 'writing');
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function requireStringField(data: Record<string, unknown>, field: string, filePath: string): string {
+  const value = data[field];
+
+  if (!isNonEmptyString(value)) {
+    throw new Error(`Invalid writing frontmatter in ${filePath}: "${field}" is required.`);
+  }
+
+  return value.trim();
+}
+
+function requireStringArrayField(
+  data: Record<string, unknown>,
+  field: string,
+  filePath: string,
+  options: { allowEmpty?: boolean } = {}
+): string[] {
+  const value = data[field];
+
+  if (!Array.isArray(value) || value.some((item) => !isNonEmptyString(item))) {
+    throw new Error(`Invalid writing frontmatter in ${filePath}: "${field}" must be a list of strings.`);
+  }
+
+  if (!options.allowEmpty && value.length === 0) {
+    throw new Error(`Invalid writing frontmatter in ${filePath}: "${field}" must not be empty.`);
+  }
+
+  return value.map((item) => item.trim());
+}
+
+function requireDateField(data: Record<string, unknown>, field: string, filePath: string): string {
+  const rawValue = data[field];
+  const value = rawValue instanceof Date ? rawValue.toISOString().slice(0, 10) : requireStringField(data, field, filePath);
+
+  if (Number.isNaN(Date.parse(value))) {
+    throw new Error(`Invalid writing frontmatter in ${filePath}: "${field}" must be a valid date string.`);
+  }
+
+  return value;
+}
+
+async function parseWritingMetadata(filePath: string, data: Record<string, unknown>): Promise<WritingMetadata> {
+  const title = requireStringField(data, 'title', filePath);
+  const slug = requireStringField(data, 'slug', filePath);
+  const date = requireDateField(data, 'date', filePath);
+  const summary = requireStringField(data, 'summary', filePath);
+  const tags = requireStringArrayField(data, 'tags', filePath);
+  const relatedProjects = requireStringArrayField(data, 'related_projects', filePath, { allowEmpty: true });
+  const validProjectSlugs = new Set(await getProjectSlugs());
+
+  for (const relatedProject of relatedProjects) {
+    if (!validProjectSlugs.has(relatedProject)) {
+      throw new Error(
+        `Invalid writing frontmatter in ${filePath}: related project "${relatedProject}" does not exist in content/projects.`
+      );
+    }
+  }
+
+  return {
+    title,
+    slug,
+    date,
+    summary,
+    tags,
+    related_projects: relatedProjects,
+  };
+}
+
+export async function getWritingEntries(): Promise<WritingEntry[]> {
+  const fileNames = await readdir(writingDirectory);
+  const writingFiles = fileNames.filter((fileName) => fileName.endsWith('.md') || fileName.endsWith('.mdx'));
+
+  const entries = await Promise.all(
+    writingFiles.map(async (fileName) => {
+      const filePath = path.join(writingDirectory, fileName);
+      const rawFile = await readFile(filePath, 'utf8');
+      const { data, content } = matter(rawFile);
+      const metadata = await parseWritingMetadata(fileName, data);
+
+      return {
+        ...metadata,
+        content: content.trim(),
+      };
+    })
+  );
+
+  const slugs = new Set<string>();
+  for (const entry of entries) {
+    if (slugs.has(entry.slug)) {
+      throw new Error(`Duplicate writing slug detected: "${entry.slug}".`);
+    }
+    slugs.add(entry.slug);
+  }
+
+  return entries.sort((left, right) => right.date.localeCompare(left.date));
+}
+
+export async function getWritingEntry(slug: string): Promise<WritingEntry | undefined> {
+  const entries = await getWritingEntries();
+  return entries.find((entry) => entry.slug === slug);
+}
+
+export async function getWritingSlugs(): Promise<string[]> {
+  const entries = await getWritingEntries();
+  return entries.map((entry) => entry.slug);
+}


### PR DESCRIPTION
## Summary

Add a static-first writing/log content model, one starter post, a writing index, and statically generated writing detail pages.

## Linked Issue Or Reference

Closes #7

## What Changed

- Added `content/writing/` with a starter post at `building-the-personal-site.md`
- Added a typed writing loader in `lib/content/writing.ts` with validation for title, slug, date, summary, tags, and related projects
- Added `/writing` as a content-driven index page and `/writing/[slug]` as a static detail route using `generateStaticParams()`
- Reused `react-markdown` to render writing body content consistently with project detail pages
- Added minimal shared styles for writing cards, tags, metadata, and detail-page layout
- Updated the README with the location and metadata shape for writing content

## Verification

```text
npm install
- succeeded; dependencies were already up to date

npm run build
- succeeded; static generation now includes /writing and /writing/building-the-personal-site

git diff --stat
- showed tracked changes to README, app/globals.css, and app/writing/page.tsx before commit
- note: new writing files were still untracked at that moment, so plain diff --stat did not list them yet

git status
- showed the intended writing-related tracked changes plus the new writing files before staging and commit

Manual local verification
- /writing rendered the writing index and starter post summary
- /writing/building-the-personal-site rendered the starter post detail page
- /writing/does-not-exist returned a 404 as expected
```

## Risk And Deployment Impact

Low-risk application and content change only. No database, CMS, auth, Docker, deployment automation, analytics, comments, newsletter features, or private infrastructure details added.

## Reviewer Focus

- Confirm the writing metadata shape and validation rules are the right minimum set for the log section
- Confirm the writing pages reuse the existing static content pattern cleanly without introducing unnecessary complexity
- Confirm the starter post content is accurate, useful, and public-safe

## Follow-Ups

- Add more writing posts as real implementation notes accumulate
- Revisit writing taxonomy and tag conventions once there are multiple posts
- Handle richer post relationships or navigation only if later issues require it