### PR TITLE
[agent-task] Add global layout, navigation, and basic visual design

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,12 +1,15 @@
 :root {
   color-scheme: light;
-  --background: #f5f1e8;
-  --surface: rgba(255, 255, 255, 0.78);
-  --border: rgba(30, 41, 59, 0.12);
-  --foreground: #1f2937;
-  --muted: #52606d;
-  --accent: #14532d;
-  --shadow: 0 20px 50px rgba(15, 23, 42, 0.08);
+  --background: #efe7db;
+  --surface: rgba(255, 252, 247, 0.82);
+  --surface-strong: rgba(255, 255, 255, 0.93);
+  --border: rgba(47, 58, 71, 0.14);
+  --foreground: #1f2933;
+  --muted: #586777;
+  --accent: #24503d;
+  --accent-soft: rgba(36, 80, 61, 0.12);
+  --shadow: 0 24px 60px rgba(20, 28, 38, 0.09);
+  --shadow-soft: 0 10px 30px rgba(20, 28, 38, 0.06);
 }
 
 * {
@@ -16,8 +19,9 @@
 html {
   font-family: Georgia, 'Times New Roman', serif;
   background:
-    radial-gradient(circle at top, rgba(20, 83, 45, 0.14), transparent 38%),
-    linear-gradient(180deg, #f8f5ef 0%, var(--background) 100%);
+    radial-gradient(circle at top left, rgba(36, 80, 61, 0.16), transparent 32%),
+    radial-gradient(circle at bottom right, rgba(157, 101, 72, 0.08), transparent 28%),
+    linear-gradient(180deg, #f7f2ea 0%, var(--background) 100%);
   color: var(--foreground);
 }
 
@@ -32,41 +36,126 @@ a {
 }
 
 .site-shell {
-  width: min(960px, calc(100% - 2rem));
+  width: min(1100px, calc(100% - 2rem));
   margin: 0 auto;
-  padding: 1.5rem 0 4rem;
+  padding: 1.5rem 0 3rem;
+}
+
+.site-frame {
+  display: grid;
+  gap: 1.5rem;
 }
 
 .site-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem 1.25rem;
+  gap: 1.5rem;
+  padding: 1.25rem 1.4rem;
   border: 1px solid var(--border);
-  border-radius: 20px;
+  border-radius: 28px;
   background: var(--surface);
   box-shadow: var(--shadow);
+  backdrop-filter: blur(8px);
+}
+
+.site-brand {
+  display: grid;
+  gap: 0.4rem;
+  max-width: 36rem;
+}
+
+.site-kicker {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
 .site-title {
-  font-size: 1.1rem;
+  font-size: clamp(1.4rem, 2vw, 1.8rem);
   font-weight: 700;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
+}
+
+.site-subtitle {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
 }
 
 .site-nav {
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.site-nav-link {
+  display: inline-flex;
+  padding: 0.65rem 0.95rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.55);
+  color: var(--muted);
+  font-size: 0.95rem;
+  font-weight: 700;
+  transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.site-nav-link:hover {
+  border-color: rgba(36, 80, 61, 0.28);
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--foreground);
+}
+
+.site-main {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.site-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem 1.35rem 0.2rem;
+  color: var(--muted);
+}
+
+.site-footer-title,
+.site-footer-copy {
+  margin: 0;
+}
+
+.site-footer-title {
+  color: var(--foreground);
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.site-footer-copy {
+  max-width: 38rem;
+  line-height: 1.6;
+}
+
+.site-footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 1rem;
   margin: 0;
   padding: 0;
   list-style: none;
-  color: var(--muted);
 }
 
-.site-main {
-  padding-top: 3rem;
+.site-footer-links a {
+  color: var(--accent);
+  font-weight: 700;
 }
 
 .stack {
@@ -74,14 +163,19 @@ a {
   gap: 1rem;
   padding: 2rem;
   border: 1px solid var(--border);
-  border-radius: 28px;
+  border-radius: 32px;
   background: var(--surface);
   box-shadow: var(--shadow);
+  backdrop-filter: blur(8px);
 }
 
 .stack-tight {
   display: grid;
   gap: 0.5rem;
+}
+
+.page-shell {
+  gap: 1.35rem;
 }
 
 .eyebrow {
@@ -95,16 +189,86 @@ a {
 
 h1 {
   margin: 0;
-  font-size: clamp(2.4rem, 7vw, 4.5rem);
-  line-height: 0.95;
+  font-size: clamp(2.8rem, 6vw, 5rem);
+  line-height: 0.94;
+  letter-spacing: -0.03em;
+}
+
+h2 {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.8vw, 2rem);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
 }
 
 .lede {
   margin: 0;
-  max-width: 58ch;
-  font-size: 1.05rem;
-  line-height: 1.7;
+  max-width: 62ch;
+  font-size: 1.08rem;
+  line-height: 1.8;
   color: var(--muted);
+}
+
+.home-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero-panel {
+  position: relative;
+  overflow: hidden;
+  gap: 1.25rem;
+}
+
+.hero-panel::after {
+  content: '';
+  position: absolute;
+  inset: auto -10% -35% 35%;
+  height: 16rem;
+  background: radial-gradient(circle, rgba(36, 80, 61, 0.12), transparent 62%);
+  pointer-events: none;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.button-link,
+.subtle-link {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  font-weight: 700;
+}
+
+.button-link {
+  padding: 0.85rem 1.2rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #f6f3ee;
+  box-shadow: var(--shadow-soft);
+}
+
+.subtle-link {
+  color: var(--accent);
+}
+
+.home-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.feature-panel {
+  gap: 0.9rem;
+}
+
+.feature-panel p:not(.eyebrow) {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.75;
 }
 
 .project-list {
@@ -113,6 +277,7 @@ h1 {
   margin: 0;
   padding: 0;
   list-style: none;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .project-card {
@@ -121,7 +286,8 @@ h1 {
   padding: 1rem 1.25rem;
   border: 1px solid var(--border);
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.72);
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-soft);
 }
 
 .project-card-header {
@@ -144,6 +310,7 @@ h1 {
   gap: 0.75rem;
   color: var(--muted);
   font-size: 0.95rem;
+  line-height: 1.6;
 }
 
 .status-pill {
@@ -152,7 +319,7 @@ h1 {
   margin: 0;
   padding: 0.35rem 0.7rem;
   border-radius: 999px;
-  background: rgba(20, 83, 45, 0.12);
+  background: var(--accent-soft);
   color: var(--accent);
   font-size: 0.85rem;
   font-weight: 700;
@@ -170,7 +337,9 @@ h1 {
 }
 
 .project-links a,
-.back-link {
+.back-link,
+.post-card h2 a,
+.project-card h2 a {
   color: var(--accent);
   font-weight: 700;
 }
@@ -181,6 +350,7 @@ h1 {
 
 .project-facts {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1rem;
   margin: 0;
 }
@@ -211,6 +381,7 @@ h1 {
   display: grid;
   gap: 1rem;
   line-height: 1.75;
+  max-width: 70ch;
 }
 
 .markdown-body > * {
@@ -228,6 +399,7 @@ h1 {
   margin: 0;
   padding: 0;
   list-style: none;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .post-card {
@@ -236,7 +408,8 @@ h1 {
   padding: 1rem 1.25rem;
   border: 1px solid var(--border);
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.72);
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-soft);
 }
 
 .post-card h2,
@@ -291,13 +464,42 @@ h1 {
 }
 
 @media (max-width: 640px) {
+  .site-shell {
+    width: min(100%, calc(100% - 1rem));
+    padding-top: 0.75rem;
+  }
+
   .site-header {
-    align-items: flex-start;
     flex-direction: column;
+    padding: 1.1rem;
+  }
+
+  .site-nav {
+    justify-content: flex-start;
+  }
+
+  .site-footer {
+    flex-direction: column;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+  }
+
+  .site-footer-links {
+    justify-content: flex-start;
   }
 
   .stack {
     padding: 1.5rem;
+  }
+
+  .home-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .project-list,
+  .post-list,
+  .project-facts {
+    grid-template-columns: 1fr;
   }
 
   h1 {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,21 +22,54 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <div className="site-shell">
-          <header className="site-header">
-            <Link className="site-title" href="/">
-              personal-site
-            </Link>
-            <nav aria-label="Primary">
-              <ul className="site-nav">
-                {navigationItems.map((item) => (
-                  <li key={item.href}>
-                    <Link href={item.href}>{item.label}</Link>
-                  </li>
-                ))}
+          <div className="site-frame">
+            <header className="site-header">
+              <div className="site-brand">
+                <p className="site-kicker">Public lab notebook</p>
+                <Link className="site-title" href="/">
+                  personal-site
+                </Link>
+                <p className="site-subtitle">
+                  Static-first project pages, writing notes, and public documentation
+                  for ongoing software work.
+                </p>
+              </div>
+              <nav aria-label="Primary">
+                <ul className="site-nav">
+                  {navigationItems.map((item) => (
+                    <li key={item.href}>
+                      <Link className="site-nav-link" href={item.href}>
+                        {item.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+            </header>
+            <main className="site-main">{children}</main>
+            <footer className="site-footer">
+              <div>
+                <p className="site-footer-title">personal-site</p>
+                <p className="site-footer-copy">
+                  A calm, static-first studio for project documentation, working notes,
+                  and links to related repositories.
+                </p>
+              </div>
+              <ul className="site-footer-links">
+                <li>
+                  <Link href="/projects">Projects</Link>
+                </li>
+                <li>
+                  <Link href="/writing">Writing</Link>
+                </li>
+                <li>
+                  <a href="https://github.com/jjmgoss/personal-site" rel="noreferrer" target="_blank">
+                    Source
+                  </a>
+                </li>
               </ul>
-            </nav>
-          </header>
-          <main className="site-main">{children}</main>
+            </footer>
+          </div>
         </div>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,51 @@
+import Link from 'next/link';
+
 export default function HomePage() {
   return (
-    <section className="stack">
-      <p className="eyebrow">Static-first project hub</p>
-      <h1>Personal site for projects, notes, and deployment writeups.</h1>
-      <p className="lede">
-        This is the initial Next.js scaffold for a content-oriented site that will
-        catalog side projects, working notes, and public documentation.
-      </p>
-    </section>
+    <div className="home-layout">
+      <section className="stack hero-panel">
+        <p className="eyebrow">Static-first project studio</p>
+        <h1>Projects, notes, and public documentation gathered into one readable place.</h1>
+        <p className="lede">
+          This site is a content-first workspace for active experiments, implementation
+          notes, deployment writeups, and the repos that support them. It is meant to
+          stay useful early, before it becomes elaborate.
+        </p>
+        <div className="hero-actions">
+          <Link className="button-link" href="/projects">
+            Browse projects
+          </Link>
+          <Link className="subtle-link" href="/writing">
+            Read the log
+          </Link>
+        </div>
+      </section>
+
+      <section className="home-grid">
+        <article className="stack feature-panel">
+          <p className="eyebrow">Projects</p>
+          <h2>Catalog active work without turning the site into a dashboard.</h2>
+          <p>
+            Project pages pull from Markdown content so status, stack choices,
+            milestones, and repo links stay easy to review in pull requests.
+          </p>
+          <Link className="subtle-link" href="/projects">
+            Open the project catalog
+          </Link>
+        </article>
+
+        <article className="stack feature-panel">
+          <p className="eyebrow">Writing</p>
+          <h2>Keep implementation notes close to the code they describe.</h2>
+          <p>
+            The writing section acts like a public lab notebook for decisions,
+            progress, and longer-form technical context.
+          </p>
+          <Link className="subtle-link" href="/writing">
+            Open the writing log
+          </Link>
+        </article>
+      </section>
+    </div>
   );
 }

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -23,7 +23,7 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
   }
 
   return (
-    <article className="stack project-detail">
+    <article className="stack page-shell project-detail">
       <Link className="back-link" href="/projects">
         Back to projects
       </Link>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -5,12 +5,12 @@ export default async function ProjectsPage() {
   const projects = await getProjectEntries();
 
   return (
-    <section className="stack">
+    <section className="stack page-shell">
       <p className="eyebrow">Projects</p>
-      <h1>Project content foundation</h1>
+      <h1>Project catalog</h1>
       <p className="lede">
-        Project entries are generated from Markdown content files so the catalog
-        stays static-first, reviewable, and easy to extend.
+        Each entry is generated from repository content files so the catalog stays
+        static-first, reviewable, and straightforward to maintain.
       </p>
       <ul className="project-list">
         {projects.map((project) => (

--- a/app/writing/[slug]/page.tsx
+++ b/app/writing/[slug]/page.tsx
@@ -23,7 +23,7 @@ export default async function WritingDetailPage({ params }: WritingDetailPagePro
   }
 
   return (
-    <article className="stack writing-detail">
+    <article className="stack page-shell writing-detail">
       <Link className="back-link" href="/writing">
         Back to writing
       </Link>

--- a/app/writing/page.tsx
+++ b/app/writing/page.tsx
@@ -5,12 +5,12 @@ export default async function WritingPage() {
   const entries = await getWritingEntries();
 
   return (
-    <section className="stack">
+    <section className="stack page-shell">
       <p className="eyebrow">Writing</p>
       <h1>Implementation notes and project log</h1>
       <p className="lede">
         Writing posts are generated from Markdown files so implementation notes,
-        project updates, and longer-form writeups stay reviewable and static-first.
+        project updates, and longer-form writeups stay reviewable, calm, and static-first.
       </p>
       <ul className="post-list">
         {entries.map((entry) => (


### PR DESCRIPTION
## Summary

Add a stronger global frame, footer, homepage structure, and responsive visual treatment so the current static content site reads as a coherent project studio.

## Linked Issue Or Reference

Closes #8

## What Changed

- Reworked the global layout header into a clearer site frame with a stronger brand block and more intentional navigation treatment
- Added a site footer with concise site context and stable navigation/source links
- Rebuilt the homepage into a clearer studio-style landing page with a hero section and two content-first entry points
- Tightened the shared styling for project cards, writing cards, detail pages, metadata panels, links, badges, and spacing
- Improved responsive behavior for the site frame, card grids, metadata sections, and footer so the layout holds together on narrow/mobile-ish widths
- Kept the current content models, routes, and static generation approach unchanged

## Verification

```text
npm install
- succeeded; dependencies were already up to date

npm run build
- succeeded; all existing static routes still built correctly

git diff --stat
- showed updates limited to the shared layout, homepage, page wrappers, and global styles

git status
- showed only the intended layout/style file changes before commit

Manual local verification
- / rendered the new homepage hero, stronger navigation, and footer
- /projects rendered the updated catalog layout and card treatment
- /projects/personal-site rendered the updated detail-page frame
- /projects/hn-trend-tracker rendered the updated detail-page frame
- /projects/repo-rails rendered the updated detail-page frame
- /writing rendered the updated writing index treatment
- /writing/building-the-personal-site rendered the updated writing detail frame
- a narrow/mobile-ish 390px-wide check on /projects kept the header, cards, and footer readable
```

Short visual description
- The site now reads like a calm public lab notebook: soft paper-toned background, stronger sectional framing, rounded card surfaces, pill-style navigation and badges, and a clearer landing page without adding animation or JavaScript state.

## Risk And Deployment Impact

Low-risk presentation-only change. No content schema changes, product feature changes, deployment changes, analytics, external scripts, or private infrastructure details added.

## Reviewer Focus

- Confirm the stronger header/footer and homepage framing improve clarity without feeling overdesigned
- Confirm the updated card/detail styling stays readable and consistent across projects and writing pages
- Confirm the responsive behavior is sufficient for an early mobile-friendly version without introducing unnecessary complexity

## Follow-Ups

- Revisit active-nav treatment later only if the site needs clearer current-page affordances
- Add richer design polish only if later issues justify more visual differentiation
- Keep future content additions aligned with the shared card and detail-page patterns