### PR TITLE
[agent-task] Add Dockerfile and local docker-compose production test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,11 @@
-node_modules/
-.next/
-out/
+.git
+.gitignore
+.next
+node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
-.DS_Store
 .env
 .env.local
 .env*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+COPY package.json package-lock.json ./
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/content ./content
+COPY --from=builder /app/next.config.ts ./next.config.ts
+EXPOSE 3000
+CMD ["npm", "run", "start", "--", "--hostname", "0.0.0.0", "--port", "3000"]

--- a/README.md
+++ b/README.md
@@ -88,6 +88,35 @@ Start the production server after a build:
 npm run start
 ```
 
+## Local Docker Test
+
+Build the local production image:
+
+```powershell
+docker build -t personal-site:local .
+```
+
+Run the local production container with Compose:
+
+```powershell
+docker compose up --build
+```
+
+Then verify:
+
+```text
+http://localhost:3000
+http://localhost:3000/projects
+http://localhost:3000/writing
+```
+
+Stop the local production container cleanly with Ctrl+C in the compose terminal,
+or run:
+
+```powershell
+docker compose stop
+```
+
 ## Project Content
 
 Project entries live in `content/projects/` as Markdown files with frontmatter.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  personal-site:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: personal-site:local
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: production


### PR DESCRIPTION
## Summary
- add a production Dockerfile with a multi-stage Next.js build
- add local docker-compose wiring and a Docker-focused ignore file
- update README and .gitignore for local Docker testing and env-file safety

## Verification
- npm install ✅
- npm run build ✅
- docker compose config ✅
- docker build -t personal-site:local . ⚠️ blocked locally because the Docker daemon pipe //./pipe/dockerDesktopLinuxEngine is unavailable in this session
- docker compose up --build ⚠️ blocked locally for the same Docker daemon reason

Closes #9