### PR TITLE
[deployment] Document Synology LAN deployment process

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ or run:
 docker compose stop
 ```
 
+For the first Synology LAN deployment path, see `docs/synology-lan-deployment.md`.
+
 ## Project Content
 
 Project entries live in `content/projects/` as Markdown files with frontmatter.

--- a/docs/deployment-strategy.md
+++ b/docs/deployment-strategy.md
@@ -125,6 +125,8 @@ Build and test locally
   -> verify on LAN
 ```
 
+The current LAN-only deployment guide lives in `docs/synology-lan-deployment.md`.
+
 Only after LAN deployment works should public routing be configured.
 
 ## Public Access Options

--- a/docs/synology-lan-deployment.md
+++ b/docs/synology-lan-deployment.md
@@ -1,0 +1,298 @@
+# Synology LAN Deployment
+
+## Overview
+
+This guide documents the first manual deployment path for running the existing Dockerized `personal-site` app on a Synology system inside the local network.
+
+The scope is intentionally narrow:
+
+- LAN-only deployment
+- public-safe placeholders only
+- manual operator steps
+- reuse of the existing `Dockerfile` and `docker-compose.yml`
+
+This guide does not change app behavior, container behavior, public routing, or deployment automation.
+
+## Current Deployment Goal
+
+The current goal is to run the site on a Synology host so it is reachable from devices on the same LAN at:
+
+```text
+http://<synology-host>:3000
+```
+
+This is the first hosted deployment step after local Docker verification.
+
+## Non-Goals
+
+This guide does not cover:
+
+- public internet exposure
+- Caddy setup
+- Cloudflare Tunnel
+- DDNS
+- router port forwarding
+- public DNS
+- HTTPS certificates
+- auto-deploy workflows
+- secrets management beyond placeholder-safe guidance
+
+Those belong to later deployment issues.
+
+## Prerequisites
+
+Before starting, confirm the following:
+
+- the repository has been pushed to a reachable Git host
+- Synology has Docker Engine support available through Docker or Container Manager
+- `docker compose` or a Container Manager-compatible compose workflow is available on Synology
+- the deploy operator can access the Synology host through a normal, approved admin path
+- the chosen Synology destination has enough space for the repository, image layers, and logs
+- the local machine has already verified the app with `npm run build`
+- the local machine has already verified the Docker configuration with `docker compose config`
+
+## Expected Deployment Shape
+
+The expected shape is a single application container built from this repository:
+
+```text
+Git checkout on Synology
+  -> docker compose build
+  -> personal-site container
+  -> port 3000 exposed on the LAN
+```
+
+Expected runtime characteristics:
+
+- one service: `personal-site`
+- one exposed port: `3000`
+- no database
+- no persistent application volume required for normal operation
+- no committed secrets
+
+## Public-Safe Placeholders
+
+Use placeholders like these in local notes, checklists, or commands:
+
+```text
+<synology-host>
+<deploy-user>
+<app-directory>
+<repo-url>
+http://<synology-host>:3000
+```
+
+Do not commit or publish:
+
+- internal IP addresses
+- private hostnames
+- real usernames
+- real deployment paths
+- tokens or secrets
+- SSH keys
+- `.env` contents
+
+## Step 1: Verify Locally
+
+Before touching Synology, verify the current checkout locally:
+
+```powershell
+npm install
+npm run build
+docker compose config
+docker compose up --build
+```
+
+Verify these routes locally:
+
+```text
+http://localhost:3000
+http://localhost:3000/projects
+http://localhost:3000/writing
+```
+
+Stop the local compose run cleanly when finished:
+
+```powershell
+docker compose stop
+```
+
+If the local Docker flow is not healthy, do not proceed to Synology yet.
+
+## Step 2: Prepare Synology Destination
+
+Choose or create a deployment directory on Synology using a placeholder-safe path convention:
+
+```text
+<app-directory>
+```
+
+The directory should be used for:
+
+- the git checkout
+- the compose file
+- Docker build context
+- normal operator access for updates and rollback
+
+Keep the path stable so update and rollback steps stay simple.
+
+## Step 3: Get The Repo Onto Synology
+
+Clone the repository onto Synology, or update an existing checkout.
+
+Fresh checkout example:
+
+```bash
+git clone <repo-url> <app-directory>
+cd <app-directory>
+```
+
+Existing checkout example:
+
+```bash
+cd <app-directory>
+git pull
+```
+
+Optional safety check:
+
+```bash
+git status
+docker compose config
+```
+
+The working tree should be clean before starting or updating the deployment.
+
+## Step 4: Build And Start With Docker Compose
+
+From the Synology checkout directory:
+
+```bash
+cd <app-directory>
+docker compose up --build -d
+```
+
+Then confirm the service is running:
+
+```bash
+docker compose ps
+```
+
+If Synology Container Manager is being used instead of a raw shell session, use the same repository files and equivalent compose-project actions:
+
+- select the repo checkout as the compose project source
+- review the rendered compose configuration
+- build the image from the current checkout
+- start the `personal-site` service
+- confirm port `3000` is published
+
+The guide still assumes the committed `docker-compose.yml` remains the source of truth.
+
+## Step 5: Verify On The LAN
+
+From another device on the same network, or from the Synology host itself, verify:
+
+```text
+http://<synology-host>:3000
+http://<synology-host>:3000/projects
+http://<synology-host>:3000/writing
+```
+
+Confirm:
+
+- the homepage loads
+- the projects page loads
+- the writing page loads
+- the site is not being treated as a public deployment
+
+## Step 6: Inspect Logs
+
+If the service is up but the site is not behaving as expected, inspect logs:
+
+```bash
+cd <app-directory>
+docker compose logs --tail=100 personal-site
+```
+
+Useful checks:
+
+- start-up errors
+- container exit loops
+- missing files in the build context
+- port binding failures
+
+## Updating The Deployment
+
+Use a safe, manual update path:
+
+```bash
+cd <app-directory>
+git pull
+docker compose config
+docker compose up --build -d
+docker compose ps
+```
+
+Then re-run the LAN verification URLs.
+
+Update only after the new revision has already passed local verification.
+
+## Rollback
+
+If a newly deployed revision fails, return to the last known good revision:
+
+```bash
+cd <app-directory>
+git checkout <previous-known-good-commit>
+docker compose up --build -d
+docker compose ps
+```
+
+Then verify again on the LAN:
+
+```text
+http://<synology-host>:3000
+```
+
+Record which revision failed and what was observed before trying another update.
+
+## Troubleshooting
+
+If the site does not come up cleanly, check the following:
+
+- `docker compose config` does not report config errors
+- the Synology host has enough free space for the image build
+- port `3000` is not already occupied by another service
+- the checkout contains the expected `Dockerfile` and `docker-compose.yml`
+- the container is still running after start-up
+- the LAN client can resolve or reach `<synology-host>`
+
+If local Docker verification worked but Synology fails, compare:
+
+- Docker version
+- Compose support
+- checkout state on Synology
+- published port configuration
+
+## Safety Checklist
+
+Before considering this deployment ready, confirm:
+
+- only placeholder values appear in docs or saved notes meant for the repo
+- no internal IPs or private hostnames were committed
+- no secrets were added to tracked files
+- the site is reachable only on the LAN deployment path described here
+- no reverse proxy, tunnel, public DNS, or router exposure was added as part of this guide
+- rollback steps have been tested or at least walked through on paper
+
+## Future Public Deployment Work
+
+Later deployment issues may add:
+
+- reverse proxy configuration
+- public DNS and routing
+- HTTPS
+- selective exposure of additional services
+- deployment automation
+
+Those steps should be documented separately so the first LAN-only deployment path stays simple and public-safe.


### PR DESCRIPTION
## Summary
Add a public-safe manual guide for deploying the existing Dockerized site to a Synology host on the local network.

## Linked Issue Or Reference
Closes #10

## What Changed
- added docs/synology-lan-deployment.md with LAN-only deployment scope, placeholder conventions, manual deployment steps, verification, rollback, troubleshooting, and safety notes
- added a short README link to the Synology LAN deployment guide from the local Docker section
- added a short note in docs/deployment-strategy.md pointing to the new LAN-only guide

## Verification
- git diff --stat
  - showed documentation updates to README.md and docs/deployment-strategy.md; the new doc file remained untracked until staging, as expected
- git status
  - showed only README.md, docs/deployment-strategy.md, and docs/synology-lan-deployment.md
- 
pm run build
  - succeeded

## Risk And Deployment Impact
- docs-only change
- no app runtime, Docker runtime behavior, CI workflow, or deployment automation changes
- no real Synology deployment commands were run in this PR

## Reviewer Focus
- confirm the guide stays LAN-only and does not drift into public exposure or HTTPS work
- confirm placeholder usage remains public-safe throughout
- confirm the steps match the current Dockerfile and docker-compose.yml

## Follow-Ups
- future issues can document public routing, reverse proxy setup, HTTPS, or deployment automation separately once LAN-only deployment is stable