### PR TITLE
[agent-task] Add screenshots and polish project pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Project entries live in `content/projects/` as Markdown files with frontmatter.
 Each project entry should define metadata such as title, slug, status, summary,
 stack, next milestone, and public-safe repository or docs URLs.
 
+Optional project screenshots should live under `public/projects/<project-slug>/` and
+be referenced from the `screenshots` frontmatter field using public-safe assets only.
+
 ## Writing Content
 
 Writing and log posts live in `content/writing/` as Markdown files with frontmatter.

--- a/app/globals.css
+++ b/app/globals.css
@@ -290,6 +290,21 @@ h2 {
   box-shadow: var(--shadow-soft);
 }
 
+.project-card-visual {
+  display: block;
+  overflow: hidden;
+  border: 1px solid rgba(36, 80, 61, 0.12);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(239, 231, 219, 0.92));
+}
+
+.project-card-image {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+}
+
 .project-card-header {
   display: grid;
   gap: 0.75rem;
@@ -346,6 +361,42 @@ h2 {
 
 .project-detail {
   gap: 1.5rem;
+}
+
+.project-gallery {
+  gap: 1rem;
+}
+
+.project-screenshot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.project-screenshot-card {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-soft);
+}
+
+.project-screenshot-image {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  border-radius: 12px;
+  border: 1px solid rgba(36, 80, 61, 0.12);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(239, 231, 219, 0.9));
+}
+
+.project-screenshot-card figcaption {
+  color: var(--muted);
+  line-height: 1.6;
 }
 
 .project-facts {
@@ -498,7 +549,8 @@ h2 {
 
   .project-list,
   .post-list,
-  .project-facts {
+  .project-facts,
+  .project-screenshot-grid {
     grid-template-columns: 1fr;
   }
 

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -64,6 +64,22 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
           </li>
         ) : null}
       </ul>
+      {project.screenshots?.length ? (
+        <section className="project-gallery stack-tight">
+          <div className="stack-tight">
+            <p className="eyebrow">Visuals</p>
+            <h2>Screenshots and artifacts</h2>
+          </div>
+          <div className="project-screenshot-grid">
+            {project.screenshots.map((screenshot) => (
+              <figure className="project-screenshot-card" key={screenshot.src}>
+                <img alt={screenshot.alt} className="project-screenshot-image" src={screenshot.src} />
+                {screenshot.caption ? <figcaption>{screenshot.caption}</figcaption> : null}
+              </figure>
+            ))}
+          </div>
+        </section>
+      ) : null}
       <div className="markdown-body">
         <ReactMarkdown>{project.content}</ReactMarkdown>
       </div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -15,6 +15,15 @@ export default async function ProjectsPage() {
       <ul className="project-list">
         {projects.map((project) => (
           <li className="project-card" key={project.slug}>
+            {project.screenshots?.[0] ? (
+              <Link className="project-card-visual" href={`/projects/${project.slug}`}>
+                <img
+                  alt={project.screenshots[0].alt}
+                  className="project-card-image"
+                  src={project.screenshots[0].src}
+                />
+              </Link>
+            ) : null}
             <div className="project-card-header">
               <div className="stack-tight">
                 <p className="status-pill">{project.status}</p>
@@ -24,6 +33,9 @@ export default async function ProjectsPage() {
               </div>
               <p>{project.summary}</p>
             </div>
+            {project.screenshots?.length ? (
+              <p className="project-meta">Visuals: {project.screenshots.length}</p>
+            ) : null}
             <p className="project-meta">
               <span>Stack: {project.stack.join(' · ')}</span>
             </p>

--- a/content/projects/personal-site.md
+++ b/content/projects/personal-site.md
@@ -12,6 +12,10 @@ next_milestone: Expand project content and add the first writing and log pages.
 repo_url: https://github.com/jjmgoss/personal-site
 live_url:
 docs_url: https://github.com/jjmgoss/personal-site/tree/main/docs
+screenshots:
+  - src: /projects/personal-site/overview.svg
+    alt: Placeholder overview illustration for the personal-site project page.
+    caption: Public-safe placeholder artwork showing the site as a calm, static-first project studio.
 ---
 
 `personal-site` is the public home base for the projects in this workspace.

--- a/lib/content/projects.ts
+++ b/lib/content/projects.ts
@@ -13,6 +13,12 @@ const PROJECT_STATUSES = [
 
 export type ProjectStatus = (typeof PROJECT_STATUSES)[number];
 
+export type ProjectScreenshot = {
+  src: string;
+  alt: string;
+  caption?: string;
+};
+
 export type ProjectMetadata = {
   title: string;
   slug: string;
@@ -23,6 +29,7 @@ export type ProjectMetadata = {
   repo_url: string;
   live_url?: string;
   docs_url?: string;
+  screenshots?: ProjectScreenshot[];
 };
 
 export type ProjectEntry = ProjectMetadata & {
@@ -51,6 +58,35 @@ function isOptionalUrl(value: unknown): value is string | undefined {
 
 function toOptionalString(value: unknown): string | undefined {
   return isNonEmptyString(value) ? value.trim() : undefined;
+}
+
+function parseScreenshots(value: unknown, filePath: string): ProjectScreenshot[] | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid project frontmatter in ${filePath}: "screenshots" must be a list when provided.`);
+  }
+
+  return value.map((item, index) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      throw new Error(
+        `Invalid project frontmatter in ${filePath}: "screenshots[${index}]" must be an object.`
+      );
+    }
+
+    const screenshot = item as Record<string, unknown>;
+    const src = requireStringField(screenshot, 'src', filePath);
+    const alt = requireStringField(screenshot, 'alt', filePath);
+    const caption = toOptionalString(screenshot.caption);
+
+    return {
+      src,
+      alt,
+      caption,
+    };
+  });
 }
 
 function parseProjectMetadata(filePath: string, data: Record<string, unknown>): ProjectMetadata {
@@ -88,6 +124,7 @@ function parseProjectMetadata(filePath: string, data: Record<string, unknown>): 
     repo_url: repoUrl,
     live_url: toOptionalString(data.live_url),
     docs_url: toOptionalString(data.docs_url),
+    screenshots: parseScreenshots(data.screenshots, filePath),
   };
 }
 

--- a/public/projects/personal-site/overview.svg
+++ b/public/projects/personal-site/overview.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 750" role="img" aria-labelledby="title desc">
+  <title id="title">personal-site placeholder overview</title>
+  <desc id="desc">Abstract public-safe placeholder artwork representing a static-first project studio.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f7f2ea"/>
+      <stop offset="100%" stop-color="#e6dccb"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#f0eadf" stop-opacity="0.92"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="750" fill="url(#bg)" rx="36"/>
+  <circle cx="180" cy="150" r="120" fill="#dfe9df"/>
+  <circle cx="1030" cy="620" r="150" fill="#e7d6ca"/>
+  <rect x="115" y="105" width="970" height="105" rx="24" fill="url(#card)" stroke="#d6c9b7"/>
+  <rect x="115" y="245" width="470" height="375" rx="28" fill="url(#card)" stroke="#d6c9b7"/>
+  <rect x="615" y="245" width="470" height="175" rx="28" fill="url(#card)" stroke="#d6c9b7"/>
+  <rect x="615" y="445" width="470" height="175" rx="28" fill="url(#card)" stroke="#d6c9b7"/>
+  <rect x="160" y="138" width="130" height="18" rx="9" fill="#24503d" fill-opacity="0.18"/>
+  <rect x="160" y="170" width="330" height="20" rx="10" fill="#1f2933" fill-opacity="0.12"/>
+  <rect x="690" y="138" width="120" height="34" rx="17" fill="#24503d" fill-opacity="0.14"/>
+  <rect x="835" y="138" width="120" height="34" rx="17" fill="#24503d" fill-opacity="0.14"/>
+  <rect x="980" y="138" width="60" height="34" rx="17" fill="#24503d" fill-opacity="0.14"/>
+  <rect x="160" y="285" width="140" height="18" rx="9" fill="#24503d" fill-opacity="0.18"/>
+  <rect x="160" y="325" width="320" height="28" rx="14" fill="#1f2933" fill-opacity="0.12"/>
+  <rect x="160" y="375" width="360" height="16" rx="8" fill="#1f2933" fill-opacity="0.08"/>
+  <rect x="160" y="405" width="310" height="16" rx="8" fill="#1f2933" fill-opacity="0.08"/>
+  <rect x="160" y="435" width="270" height="16" rx="8" fill="#1f2933" fill-opacity="0.08"/>
+  <rect x="160" y="500" width="160" height="42" rx="21" fill="#24503d"/>
+  <rect x="650" y="285" width="120" height="16" rx="8" fill="#24503d" fill-opacity="0.18"/>
+  <rect x="650" y="320" width="270" height="24" rx="12" fill="#1f2933" fill-opacity="0.12"/>
+  <rect x="650" y="365" width="390" height="14" rx="7" fill="#1f2933" fill-opacity="0.08"/>
+  <rect x="650" y="485" width="120" height="16" rx="8" fill="#24503d" fill-opacity="0.18"/>
+  <rect x="650" y="520" width="250" height="24" rx="12" fill="#1f2933" fill-opacity="0.12"/>
+  <rect x="650" y="565" width="370" height="14" rx="7" fill="#1f2933" fill-opacity="0.08"/>
+</svg>


### PR DESCRIPTION
## Summary
Add optional public-safe screenshot support for project content, render screenshots cleanly on project detail pages, surface a lightweight visual preview on the project index, and document the image storage convention.

## Linked Issue Or Reference
Closes #14

## What Changed
- added optional `screenshots` metadata validation in `lib/content/projects.ts`
- updated `app/projects/page.tsx` to show a lightweight visual preview and visual count when screenshots are present
- updated `app/projects/[slug]/page.tsx` to render a screenshot/artifact gallery only when screenshots exist
- polished project-page presentation in `app/globals.css` for image cards and gallery layout
- added one public-safe placeholder SVG at `public/projects/personal-site/overview.svg` and referenced it from `content/projects/personal-site.md`
- documented the screenshot storage convention in `README.md`

## Verification
- `npm run build`
  - succeeded
- `git diff --stat`
  - before staging, showed the intended screenshot-support changes plus an unrelated pre-existing local modification to `AGENTS.md`; that unrelated file was left out of the commit
- `git status`
  - before commit, showed the intended task files along with the unrelated pre-existing local modification to `AGENTS.md`
- manual local verification
  - `/projects` rendered with the new personal-site visual preview
  - `/projects/personal-site` rendered the placeholder screenshot and caption
  - `/projects/hn-trend-tracker` rendered cleanly without a screenshot section
  - `/projects/repo-rails` rendered cleanly without a screenshot section

## Risk And Deployment Impact
- low risk UI and content-model enhancement only
- no deployment, Docker, Synology, public routing, or writing-content changes
- missing screenshots continue to render gracefully because the gallery is optional

## Reviewer Focus
- confirm the `screenshots` frontmatter shape and validation are strict enough without overcomplicating the content model
- confirm the new project visuals stay public-safe and do not imply private infrastructure details
- confirm the project index and detail styling feel more polished without broadening into unrelated site-wide design changes

## Follow-Ups
- if more visuals are added later, consider whether multiple projects should receive public-safe screenshots once suitable assets exist