### PR TITLE
Replace placeholder site identity and tighten public presentation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -36,9 +36,9 @@ a {
 }
 
 .site-shell {
-  width: min(1100px, calc(100% - 2rem));
+  width: min(1040px, calc(100% - 2rem));
   margin: 0 auto;
-  padding: 1.5rem 0 3rem;
+  padding: 1.1rem 0 2.4rem;
 }
 
 .site-frame {
@@ -51,9 +51,9 @@ a {
   align-items: flex-start;
   justify-content: space-between;
   gap: 1.5rem;
-  padding: 1.25rem 1.4rem;
-  border: 1px solid var(--border);
-  border-radius: 28px;
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(47, 58, 71, 0.12);
+  border-radius: 24px;
   background: var(--surface);
   box-shadow: var(--shadow);
   backdrop-filter: blur(8px);
@@ -61,21 +61,21 @@ a {
 
 .site-brand {
   display: grid;
-  gap: 0.4rem;
-  max-width: 36rem;
+  gap: 0.3rem;
+  max-width: 38rem;
 }
 
 .site-kicker {
   margin: 0;
   color: var(--accent);
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   font-weight: 700;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
 .site-title {
-  font-size: clamp(1.4rem, 2vw, 1.8rem);
+  font-size: clamp(1.35rem, 1.7vw, 1.7rem);
   font-weight: 700;
   letter-spacing: 0.01em;
 }
@@ -83,7 +83,8 @@ a {
 .site-subtitle {
   margin: 0;
   color: var(--muted);
-  line-height: 1.6;
+  line-height: 1.5;
+  max-width: 34rem;
 }
 
 .site-nav {
@@ -98,12 +99,12 @@ a {
 
 .site-nav-link {
   display: inline-flex;
-  padding: 0.65rem 0.95rem;
+  padding: 0.55rem 0.9rem;
   border: 1px solid var(--border);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.55);
   color: var(--muted);
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   font-weight: 700;
   transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
 }
@@ -116,14 +117,14 @@ a {
 
 .site-main {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.2rem;
 }
 
 .site-footer {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  padding: 1.1rem 1.35rem 0.2rem;
+  padding: 0.8rem 0.5rem 0;
   color: var(--muted);
 }
 
@@ -160,10 +161,10 @@ a {
 
 .stack {
   display: grid;
-  gap: 1rem;
-  padding: 2rem;
+  gap: 0.9rem;
+  padding: 1.5rem;
   border: 1px solid var(--border);
-  border-radius: 32px;
+  border-radius: 24px;
   background: var(--surface);
   box-shadow: var(--shadow);
   backdrop-filter: blur(8px);
@@ -189,23 +190,29 @@ a {
 
 h1 {
   margin: 0;
-  font-size: clamp(2.8rem, 6vw, 5rem);
-  line-height: 0.94;
-  letter-spacing: -0.03em;
+  font-size: clamp(2.2rem, 4.6vw, 3.9rem);
+  line-height: 0.98;
+  letter-spacing: -0.025em;
 }
 
 h2 {
   margin: 0;
-  font-size: clamp(1.4rem, 2.8vw, 2rem);
-  line-height: 1.05;
+  font-size: clamp(1.25rem, 2.2vw, 1.7rem);
+  line-height: 1.12;
   letter-spacing: -0.02em;
+}
+
+h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.25;
 }
 
 .lede {
   margin: 0;
-  max-width: 62ch;
-  font-size: 1.08rem;
-  line-height: 1.8;
+  max-width: 60ch;
+  font-size: 1rem;
+  line-height: 1.65;
   color: var(--muted);
 }
 
@@ -217,7 +224,12 @@ h2 {
 .hero-panel {
   position: relative;
   overflow: hidden;
-  gap: 1.25rem;
+  gap: 1rem;
+}
+
+.hero-panel-compact {
+  padding-top: 1.7rem;
+  padding-bottom: 1.7rem;
 }
 
 .hero-panel::after {
@@ -232,7 +244,7 @@ h2 {
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.85rem;
+  gap: 0.7rem;
 }
 
 .button-link,
@@ -244,7 +256,7 @@ h2 {
 }
 
 .button-link {
-  padding: 0.85rem 1.2rem;
+  padding: 0.75rem 1.05rem;
   border-radius: 999px;
   background: var(--accent);
   color: #f6f3ee;
@@ -255,25 +267,92 @@ h2 {
   color: var(--accent);
 }
 
+.hero-support {
+  margin: 0;
+  max-width: 54ch;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
 .home-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1.5rem;
+  gap: 1.2rem;
+}
+
+.home-grid-balanced {
+  align-items: start;
 }
 
 .feature-panel {
-  gap: 0.9rem;
+  gap: 0.8rem;
 }
 
 .feature-panel p:not(.eyebrow) {
   margin: 0;
   color: var(--muted);
-  line-height: 1.75;
+  line-height: 1.65;
+}
+
+.preview-list {
+  display: grid;
+  gap: 0.85rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.preview-item {
+  display: grid;
+  gap: 0.35rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid rgba(47, 58, 71, 0.12);
+}
+
+.preview-item:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.preview-item p {
+  color: var(--muted);
+}
+
+.preview-item-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.preview-item-heading a,
+.note-spotlight h3 a {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.preview-item-heading span {
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-transform: capitalize;
+}
+
+.note-spotlight {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid rgba(47, 58, 71, 0.12);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.note-spotlight p {
+  margin: 0;
 }
 
 .project-list {
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -282,8 +361,8 @@ h2 {
 
 .project-card {
   display: grid;
-  gap: 1rem;
-  padding: 1rem 1.25rem;
+  gap: 0.8rem;
+  padding: 0.95rem 1rem;
   border: 1px solid var(--border);
   border-radius: 18px;
   background: var(--surface-strong);
@@ -294,7 +373,7 @@ h2 {
   display: block;
   overflow: hidden;
   border: 1px solid rgba(36, 80, 61, 0.12);
-  border-radius: 14px;
+  border-radius: 12px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(239, 231, 219, 0.92));
 }
 
@@ -307,7 +386,7 @@ h2 {
 
 .project-card-header {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.45rem;
 }
 
 .project-card h2,
@@ -316,16 +395,21 @@ h2 {
 }
 
 .project-card h2 {
-  font-size: 1.5rem;
+  font-size: 1.3rem;
+}
+
+.card-copy {
+  color: var(--foreground);
+  line-height: 1.55;
 }
 
 .project-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.55rem;
   color: var(--muted);
-  font-size: 0.95rem;
-  line-height: 1.6;
+  font-size: 0.88rem;
+  line-height: 1.45;
 }
 
 .status-pill {
@@ -360,7 +444,7 @@ h2 {
 }
 
 .project-detail {
-  gap: 1.5rem;
+  gap: 1.2rem;
 }
 
 .project-gallery {
@@ -377,9 +461,9 @@ h2 {
   display: grid;
   gap: 0.75rem;
   margin: 0;
-  padding: 0.9rem;
+  padding: 0.8rem;
   border: 1px solid var(--border);
-  border-radius: 18px;
+  border-radius: 16px;
   background: var(--surface-strong);
   box-shadow: var(--shadow-soft);
 }
@@ -409,9 +493,9 @@ h2 {
 .project-facts div {
   display: grid;
   gap: 0.35rem;
-  padding: 1rem 1.25rem;
+  padding: 0.85rem 1rem;
   border: 1px solid var(--border);
-  border-radius: 18px;
+  border-radius: 16px;
   background: rgba(255, 255, 255, 0.56);
 }
 
@@ -446,7 +530,7 @@ h2 {
 
 .post-list {
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -455,8 +539,8 @@ h2 {
 
 .post-card {
   display: grid;
-  gap: 1rem;
-  padding: 1rem 1.25rem;
+  gap: 0.8rem;
+  padding: 0.95rem 1rem;
   border: 1px solid var(--border);
   border-radius: 18px;
   background: var(--surface-strong);
@@ -469,7 +553,7 @@ h2 {
 }
 
 .post-card h2 {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
 }
 
 .post-date {
@@ -522,7 +606,7 @@ h2 {
 
   .site-header {
     flex-direction: column;
-    padding: 1.1rem;
+    padding: 1rem;
   }
 
   .site-nav {
@@ -540,7 +624,7 @@ h2 {
   }
 
   .stack {
-    padding: 1.5rem;
+    padding: 1.2rem;
   }
 
   .home-grid {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,15 +3,16 @@ import Link from 'next/link';
 import './globals.css';
 
 export const metadata: Metadata = {
-  title: 'personal-site',
-  description: 'A static-first hub for projects, notes, and writing.',
+  title: {
+    default: 'Jason Goss',
+    template: '%s | Jason Goss',
+  },
+  description: 'Software projects, technical notes, and AI-assisted experiments by Jason Goss.',
 };
 
 const navigationItems = [
-  { href: '/', label: 'Home' },
   { href: '/projects', label: 'Projects' },
-  { href: '/writing', label: 'Writing' },
-  { href: '/now', label: 'Now' },
+  { href: '/writing', label: 'Notes' },
 ];
 
 export default function RootLayout({
@@ -26,13 +27,13 @@ export default function RootLayout({
           <div className="site-frame">
             <header className="site-header">
               <div className="site-brand">
-                <p className="site-kicker">Public lab notebook</p>
+                <p className="site-kicker">Software projects and notes</p>
                 <Link className="site-title" href="/">
-                  personal-site
+                  Jason Goss
                 </Link>
                 <p className="site-subtitle">
-                  Static-first project pages, writing notes, and public documentation
-                  for ongoing software work.
+                  AI-assisted software experiments, project notes, and work in progress
+                  aimed at getting useful work done with less manual effort.
                 </p>
               </div>
               <nav aria-label="Primary">
@@ -50,10 +51,9 @@ export default function RootLayout({
             <main className="site-main">{children}</main>
             <footer className="site-footer">
               <div>
-                <p className="site-footer-title">personal-site</p>
+                <p className="site-footer-title">Jason Goss</p>
                 <p className="site-footer-copy">
-                  A calm, static-first studio for project documentation, working notes,
-                  and links to related repositories.
+                  Projects, notes, and experiments in software, automation, and agent workflows.
                 </p>
               </div>
               <ul className="site-footer-links">
@@ -61,7 +61,7 @@ export default function RootLayout({
                   <Link href="/projects">Projects</Link>
                 </li>
                 <li>
-                  <Link href="/writing">Writing</Link>
+                  <Link href="/writing">Notes</Link>
                 </li>
                 <li>
                   <Link href="/now">Now</Link>

--- a/app/now/page.tsx
+++ b/app/now/page.tsx
@@ -1,11 +1,17 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Now',
+  description: 'A current snapshot of Jason Goss projects, priorities, and work in progress.',
+};
 
 const activeProjects = [
   {
     href: '/projects/personal-site',
-    title: 'personal-site',
+    title: 'Personal Site',
     summary:
-      'The main hub for project documentation, writing, and deployment notes. The current focus is making the site clearer and more useful before public launch.',
+      'The portfolio and notes hub itself. Right now the work is tightening the public presentation so it feels stable enough to share without pretending it is finished.',
   },
   {
     href: '/projects/hn-trend-tracker',
@@ -25,27 +31,27 @@ const statusSections = [
   {
     title: 'Current focus',
     body:
-      'The current focus is improving the project site itself: clearer navigation, better public-safe project summaries, more writing, and a status snapshot that explains what is finished and what is still intentionally private.',
+      'Right now the focus is sharpening the public presentation: clearer project pages, better notes, and a stronger explanation of the work without turning the site into a product pitch.',
   },
   {
-    title: 'Site status',
+    title: 'What exists now',
     body:
-      'The site is already content-driven. Project pages and writing pages are generated from Markdown content, and the app stays static-first so updates remain easy to review and cheap to host.',
+      'Projects, notes, and the current snapshot are already live in the app. The structure is simple on purpose so adding work stays lightweight instead of turning into site maintenance.',
   },
   {
     title: 'Deployment status',
     body:
-      'The site is running on a LAN-first self-hosted deployment. Local Docker and Synology deployment paths are working, and public routing has been planned but is not enabled yet.',
+      'The site runs in a LAN-first self-hosted setup today. Public routing has been planned, but it is still intentionally off while the content and presentation get stronger.',
   },
   {
-    title: 'What is not public yet',
+    title: 'What is still intentionally private',
     body:
-      'Public exposure, tunnel configuration, DNS changes, and other internet-facing deployment steps are intentionally paused. The current priority is to make the site itself more complete before turning it outward.',
+      'Internet-facing deployment, infrastructure details, and other operational mechanics are not the story yet. The goal is to make the work clearer first, then make it public.',
   },
   {
     title: 'Next milestones',
     body:
-      'The likely next steps are broadening the site content, refining the project catalog, adding more public-safe writing, and continuing UI polish so the site feels complete before public launch.',
+      'Next up: expand project coverage, keep writing down what is learned, and keep tightening the parts that make the work feel credible from the outside.',
   },
 ];
 
@@ -53,18 +59,18 @@ export default function NowPage() {
   return (
     <section className="stack page-shell">
       <p className="eyebrow">Now</p>
-      <h1>Current snapshot</h1>
+      <h1>What I’m focused on now</h1>
       <p className="lede">
-        This site is a public-safe project snapshot: what is being built, what is already
-        working, and what is intentionally still private while the site takes shape.
+        A quick snapshot of the work in motion, what feels solid enough to talk about,
+        and what is still staying behind the curtain for now.
       </p>
 
       <div className="stack-tight">
-        <h2>What this site is</h2>
+        <h2>What this is</h2>
         <p className="lede">
-          personal-site is the readable front door for ongoing software work. It gathers
-          project summaries, implementation notes, and deployment documentation into one
-          static-first place that stays reviewable and calm.
+          This site is the public-facing record of software projects, AI experiments,
+          and technical notes that are still being worked on. It is meant to stay useful,
+          direct, and honest about what is finished versus what is still taking shape.
         </p>
       </div>
 
@@ -83,8 +89,8 @@ export default function NowPage() {
       <div className="stack-tight">
         <h2>Active projects</h2>
         <p className="lede">
-          The site currently centers on a small set of active projects that are already
-          documented here and will keep expanding as the site matures.
+          The current set is small on purpose: a few projects that are active, documented,
+          and still moving.
         </p>
       </div>
 
@@ -109,7 +115,7 @@ export default function NowPage() {
             <Link href="/projects">Project catalog</Link>
           </li>
           <li>
-            <Link href="/projects/personal-site">personal-site</Link>
+            <Link href="/projects/personal-site">Personal Site</Link>
           </li>
           <li>
             <Link href="/projects/hn-trend-tracker">HN Trend Tracker</Link>
@@ -118,7 +124,7 @@ export default function NowPage() {
             <Link href="/projects/repo-rails">repo-rails</Link>
           </li>
           <li>
-            <Link href="/writing">Writing log</Link>
+            <Link href="/writing">Notes</Link>
           </li>
         </ul>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,48 +1,82 @@
 import Link from 'next/link';
+import { getProjectEntries } from '@/lib/content/projects';
+import { getWritingEntries } from '@/lib/content/writing';
 
-export default function HomePage() {
+export default async function HomePage() {
+  const [projects, notes] = await Promise.all([getProjectEntries(), getWritingEntries()]);
+  const featuredProjects = projects.slice(0, 3);
+  const latestNote = notes[0];
+
   return (
     <div className="home-layout">
-      <section className="stack hero-panel">
-        <p className="eyebrow">Static-first project studio</p>
-        <h1>Projects, notes, and public documentation gathered into one readable place.</h1>
+      <section className="stack hero-panel hero-panel-compact">
+        <p className="eyebrow">Jason Goss</p>
+        <h1>How to get the machine to do work for me.</h1>
         <p className="lede">
-          This site is a content-first workspace for active experiments, implementation
-          notes, deployment writeups, and the repos that support them. It is meant to
-          stay useful early, before it becomes elaborate.
+          I build software, automation, and AI-assisted workflows that turn rough ideas
+          into useful tools. This is the portfolio and notebook for the experiments,
+          systems, and work-in-progress projects worth sharing.
         </p>
         <div className="hero-actions">
           <Link className="button-link" href="/projects">
-            Browse projects
+            View projects
           </Link>
           <Link className="subtle-link" href="/writing">
-            Read the log
+            Read notes
           </Link>
         </div>
+        <p className="hero-support">
+          The through-line is practical: use software systems, agent workflows, and AI
+          tools to move more work with less manual drag.
+        </p>
       </section>
 
-      <section className="home-grid">
+      <section className="home-grid home-grid-balanced">
         <article className="stack feature-panel">
-          <p className="eyebrow">Projects</p>
-          <h2>Catalog active work without turning the site into a dashboard.</h2>
+          <p className="eyebrow">Selected work</p>
+          <h2>Projects first, with the rough edges left visible.</h2>
           <p>
-            Project pages pull from Markdown content so status, stack choices,
-            milestones, and repo links stay easy to review in pull requests.
+            Most of the work here is still in progress. That is the point: the site shows
+            what is actually being built, what is still getting sharper, and what seems
+            worth continuing.
           </p>
+          <ul className="preview-list">
+            {featuredProjects.map((project) => (
+              <li className="preview-item" key={project.slug}>
+                <div className="preview-item-heading">
+                  <Link href={`/projects/${project.slug}`}>{project.title}</Link>
+                  <span>{project.status}</span>
+                </div>
+                <p>{project.summary}</p>
+              </li>
+            ))}
+          </ul>
           <Link className="subtle-link" href="/projects">
-            Open the project catalog
+            Browse the full project list
           </Link>
         </article>
 
         <article className="stack feature-panel">
-          <p className="eyebrow">Writing</p>
-          <h2>Keep implementation notes close to the code they describe.</h2>
+          <p className="eyebrow">Notes</p>
+          <h2>Notes on what holds up, what breaks, and what changes next.</h2>
           <p>
-            The writing section acts like a public lab notebook for decisions,
-            progress, and longer-form technical context.
+            The notes section is where decisions, experiments, and implementation details
+            get written down before they disappear into a commit history.
           </p>
+          {latestNote ? (
+            <div className="note-spotlight">
+              <p className="post-date">Latest note</p>
+              <h3>
+                <Link href={`/writing/${latestNote.slug}`}>{latestNote.title}</Link>
+              </h3>
+              <p>{latestNote.summary}</p>
+            </div>
+          ) : null}
           <Link className="subtle-link" href="/writing">
-            Open the writing log
+            Read all notes
+          </Link>
+          <Link className="subtle-link" href="/now">
+            See the current snapshot
           </Link>
         </article>
       </section>

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
@@ -12,6 +13,22 @@ type ProjectDetailPageProps = {
 export async function generateStaticParams() {
   const slugs = await getProjectSlugs();
   return slugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: ProjectDetailPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const project = await getProjectEntry(slug);
+
+  if (!project) {
+    return {
+      title: 'Project',
+    };
+  }
+
+  return {
+    title: project.title,
+    description: project.summary,
+  };
 }
 
 export default async function ProjectDetailPage({ params }: ProjectDetailPageProps) {
@@ -67,8 +84,8 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
       {project.screenshots?.length ? (
         <section className="project-gallery stack-tight">
           <div className="stack-tight">
-            <p className="eyebrow">Visuals</p>
-            <h2>Screenshots and artifacts</h2>
+            <p className="eyebrow">Preview</p>
+            <h2>Current visual snapshot</h2>
           </div>
           <div className="project-screenshot-grid">
             {project.screenshots.map((screenshot) => (

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getProjectEntries } from '@/lib/content/projects';
+
+export const metadata: Metadata = {
+  title: 'Projects',
+  description: 'Work-in-progress software, automation, and AI experiments by Jason Goss.',
+};
 
 export default async function ProjectsPage() {
   const projects = await getProjectEntries();
@@ -7,10 +13,10 @@ export default async function ProjectsPage() {
   return (
     <section className="stack page-shell">
       <p className="eyebrow">Projects</p>
-      <h1>Project catalog</h1>
+      <h1>Projects in progress</h1>
       <p className="lede">
-        Each entry is generated from repository content files so the catalog stays
-        static-first, reviewable, and straightforward to maintain.
+        A working portfolio of tools, experiments, and systems that are getting more
+        useful over time. Some are rough. All of them are real.
       </p>
       <ul className="project-list">
         {projects.map((project) => (
@@ -31,10 +37,10 @@ export default async function ProjectsPage() {
                   <Link href={`/projects/${project.slug}`}>{project.title}</Link>
                 </h2>
               </div>
-              <p>{project.summary}</p>
+              <p className="card-copy">{project.summary}</p>
             </div>
             {project.screenshots?.length ? (
-              <p className="project-meta">Visuals: {project.screenshots.length}</p>
+              <p className="project-meta">Preview available</p>
             ) : null}
             <p className="project-meta">
               <span>Stack: {project.stack.join(' · ')}</span>

--- a/app/writing/[slug]/page.tsx
+++ b/app/writing/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
@@ -14,6 +15,22 @@ export async function generateStaticParams() {
   return slugs.map((slug) => ({ slug }));
 }
 
+export async function generateMetadata({ params }: WritingDetailPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = await getWritingEntry(slug);
+
+  if (!entry) {
+    return {
+      title: 'Notes',
+    };
+  }
+
+  return {
+    title: entry.title,
+    description: entry.summary,
+  };
+}
+
 export default async function WritingDetailPage({ params }: WritingDetailPageProps) {
   const { slug } = await params;
   const entry = await getWritingEntry(slug);
@@ -25,9 +42,9 @@ export default async function WritingDetailPage({ params }: WritingDetailPagePro
   return (
     <article className="stack page-shell writing-detail">
       <Link className="back-link" href="/writing">
-        Back to writing
+        Back to notes
       </Link>
-      <p className="eyebrow">Writing</p>
+      <p className="eyebrow">Notes</p>
       <div className="stack-tight">
         <p className="post-date">{entry.date}</p>
         <h1>{entry.title}</h1>

--- a/app/writing/page.tsx
+++ b/app/writing/page.tsx
@@ -1,16 +1,22 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getWritingEntries } from '@/lib/content/writing';
+
+export const metadata: Metadata = {
+  title: 'Notes',
+  description: 'Technical notes and build writeups from ongoing software and AI projects.',
+};
 
 export default async function WritingPage() {
   const entries = await getWritingEntries();
 
   return (
     <section className="stack page-shell">
-      <p className="eyebrow">Writing</p>
-      <h1>Implementation notes and project log</h1>
+      <p className="eyebrow">Notes</p>
+      <h1>Notes from the build process</h1>
       <p className="lede">
-        Writing posts are generated from Markdown files so implementation notes,
-        project updates, and longer-form writeups stay reviewable, calm, and static-first.
+        Short technical notes, project updates, and writeups on what is working, what is
+        changing, and what is worth keeping from the experiments.
       </p>
       <ul className="post-list">
         {entries.map((entry) => (

--- a/content/projects/personal-site.md
+++ b/content/projects/personal-site.md
@@ -2,34 +2,33 @@
 title: Personal Site
 slug: personal-site
 status: active
-summary: Static-first project hub for side projects, documentation, writing, deployment notes, and links to live demos.
+summary: Portfolio and technical-notes hub for software experiments, project delivery, and AI-assisted workflow design.
 stack:
   - Next.js
   - TypeScript
   - Markdown
   - GitHub Issues
-next_milestone: Expand project content and add the first writing and log pages.
+next_milestone: Tighten the public presentation and keep expanding project and notes coverage.
 repo_url: https://github.com/jjmgoss/personal-site
 live_url:
 docs_url: https://github.com/jjmgoss/personal-site/tree/main/docs
 screenshots:
   - src: /projects/personal-site/overview.svg
-    alt: Placeholder overview illustration for the personal-site project page.
-    caption: Public-safe placeholder artwork showing the site as a calm, static-first project studio.
+    alt: Overview illustration for the Personal Site project page.
+    caption: A simple overview graphic used until real product screenshots are worth publishing.
 ---
 
-`personal-site` is the public home base for the projects in this workspace.
+`personal-site` is the portfolio and notes hub for the work in this workspace.
 
-The site is meant to stay static-first and content-oriented. Instead of pulling
-project data from a database or CMS, it generates pages from files that are easy
-to review in pull requests and easy for coding agents to update safely.
+The goal is straightforward: keep projects, notes, and delivery experiments in one
+place that is easy to update and easy to understand from the outside.
 
-The initial scope is intentionally narrow:
+The current scope is still intentionally narrow:
 
-- a homepage that explains the project lab
-- a project catalog with detail pages
-- a writing/log section for implementation notes
-- public-safe deployment notes and links to live demos when they exist
+- a short professional landing page
+- a project catalog with honest work-in-progress status
+- notes on what is being built and what is being learned
+- deployment and process documentation when it helps explain the work
 
-The current milestone is to make the project catalog feel real with useful
-entries and then extend the same content-driven pattern to the writing section.
+The current milestone is to make the public presentation strong enough to share
+without pretending the projects are more polished than they are.

--- a/content/writing/building-the-personal-site.md
+++ b/content/writing/building-the-personal-site.md
@@ -1,8 +1,8 @@
 ---
-title: Building the Personal Site
+title: Building the Portfolio Site
 slug: building-the-personal-site
 date: 2026-05-03
-summary: Notes on building this site as a static-first project hub with Next.js, Markdown content, GitHub issues, and small agent-executed pull requests.
+summary: Notes on shaping this site into a credible portfolio and notebook for software experiments, project delivery, and AI-assisted workflows.
 tags:
   - site-building
   - nextjs
@@ -12,12 +12,13 @@ related_projects:
   - personal-site
 ---
 
-This site is being built as a static-first project hub rather than a heavy web
+This site is being built as a portfolio and notes hub rather than a heavy web
 application with a database or CMS.
 
 The goal is to keep the content easy to review, easy to update in pull requests,
-and easy to evolve one issue at a time. Project entries and writing posts live
-in Markdown files so the site can be generated from the repository itself.
+and easy to evolve one issue at a time while the public presentation gets tighter.
+Project entries and notes live in Markdown files so the site can be generated
+from the repository itself.
 
 The implementation approach is intentionally small and incremental:
 
@@ -26,5 +27,5 @@ The implementation approach is intentionally small and incremental:
 - plan work in GitHub issues
 - ship changes as focused, agent-executed pull requests
 
-That approach keeps the site public-safe and maintainable while it grows into a
-better catalog of projects, notes, and deployment writeups.
+That approach keeps the work maintainable while the site grows into a better
+record of projects, notes, and experiments worth sharing.


### PR DESCRIPTION
## Summary
- replace the public site identity with Jason Goss and shift homepage framing toward software and AI-assisted work
- rename public-facing Writing labels to Notes, move Now out of primary nav, and tighten route metadata
- calm the typography and spacing, densify project and note cards, and clean up placeholder project visual copy

Refs #34

## Verification
- npm run validate:content
- npm run build
- manual browser checks for /, /projects, /projects/personal-site, /writing, and /now
- narrow viewport check on /