### PR TITLE
[agent-task] Move public site copy into editable content files

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,18 @@ Writing and log posts live in `content/writing/` as Markdown files with frontmat
 
 Each post should define metadata such as title, slug, date, summary, tags, and
 related projects.
+
+## Editing Copy
+
+Common public site copy now lives under `content/site/`.
+
+- Edit project pages in `content/projects/`.
+- Edit notes and writing entries in `content/writing/`.
+- Edit site-level copy such as the homepage, shared header/footer text, projects intro, notes intro, and `/now` page in `content/site/`.
+
+After editing content, run:
+
+```powershell
+npm run validate:content
+npm run build
+```

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,25 +1,27 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { getSiteConfig } from '@/lib/content/site';
 import './globals.css';
 
-export const metadata: Metadata = {
-  title: {
-    default: 'Jason Goss',
-    template: '%s | Jason Goss',
-  },
-  description: 'Software projects, technical notes, and AI-assisted experiments by Jason Goss.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const siteConfig = await getSiteConfig();
 
-const navigationItems = [
-  { href: '/projects', label: 'Projects' },
-  { href: '/writing', label: 'Notes' },
-];
+  return {
+    title: {
+      default: siteConfig.title,
+      template: `%s | ${siteConfig.title}`,
+    },
+    description: siteConfig.metadataDescription,
+  };
+}
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const siteConfig = await getSiteConfig();
+
   return (
     <html lang="en">
       <body>
@@ -27,18 +29,15 @@ export default function RootLayout({
           <div className="site-frame">
             <header className="site-header">
               <div className="site-brand">
-                <p className="site-kicker">Software projects and notes</p>
+                <p className="site-kicker">{siteConfig.headerKicker}</p>
                 <Link className="site-title" href="/">
-                  Jason Goss
+                  {siteConfig.title}
                 </Link>
-                <p className="site-subtitle">
-                  AI-assisted software experiments, project notes, and work in progress
-                  aimed at getting useful work done with less manual effort.
-                </p>
+                <p className="site-subtitle">{siteConfig.headerSubtitle}</p>
               </div>
               <nav aria-label="Primary">
                 <ul className="site-nav">
-                  {navigationItems.map((item) => (
+                  {siteConfig.primaryNav.map((item) => (
                     <li key={item.href}>
                       <Link className="site-nav-link" href={item.href}>
                         {item.label}
@@ -51,26 +50,21 @@ export default function RootLayout({
             <main className="site-main">{children}</main>
             <footer className="site-footer">
               <div>
-                <p className="site-footer-title">Jason Goss</p>
-                <p className="site-footer-copy">
-                  Projects, notes, and experiments in software, automation, and agent workflows.
-                </p>
+                <p className="site-footer-title">{siteConfig.footerTitle}</p>
+                <p className="site-footer-copy">{siteConfig.footerSummary}</p>
               </div>
               <ul className="site-footer-links">
-                <li>
-                  <Link href="/projects">Projects</Link>
-                </li>
-                <li>
-                  <Link href="/writing">Notes</Link>
-                </li>
-                <li>
-                  <Link href="/now">Now</Link>
-                </li>
-                <li>
-                  <a href="https://github.com/jjmgoss/personal-site" rel="noreferrer" target="_blank">
-                    Source
-                  </a>
-                </li>
+                {siteConfig.footerLinks.map((item) => (
+                  <li key={item.href}>
+                    {item.href.startsWith('/') ? (
+                      <Link href={item.href}>{item.label}</Link>
+                    ) : (
+                      <a href={item.href} rel="noreferrer" target="_blank">
+                        {item.label}
+                      </a>
+                    )}
+                  </li>
+                ))}
               </ul>
             </footer>
           </div>

--- a/app/now/page.tsx
+++ b/app/now/page.tsx
@@ -1,81 +1,34 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { getProjectEntries } from '@/lib/content/projects';
+import { getNowContent } from '@/lib/content/site';
 
-export const metadata: Metadata = {
-  title: 'Now',
-  description: 'A current snapshot of Jason Goss projects, priorities, and work in progress.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const pageContent = await getNowContent();
 
-const activeProjects = [
-  {
-    href: '/projects/personal-site',
-    title: 'Personal Site',
-    summary:
-      'The portfolio and notes hub itself. Right now the work is tightening the public presentation so it feels stable enough to share without pretending it is finished.',
-  },
-  {
-    href: '/projects/hn-trend-tracker',
-    title: 'HN Trend Tracker',
-    summary:
-      'A separate project exploring Hacker News trend collection, analysis, and presentation. It remains one of the active projects documented from this site.',
-  },
-  {
-    href: '/projects/repo-rails',
-    title: 'repo-rails',
-    summary:
-      'A tooling project for repo structure, policy, and review workflows that supports repeatable setup across project repositories.',
-  },
-];
+  return {
+    title: pageContent.metadataTitle,
+    description: pageContent.metadataDescription,
+  };
+}
 
-const statusSections = [
-  {
-    title: 'Current focus',
-    body:
-      'Right now the focus is sharpening the public presentation: clearer project pages, better notes, and a stronger explanation of the work without turning the site into a product pitch.',
-  },
-  {
-    title: 'What exists now',
-    body:
-      'Projects, notes, and the current snapshot are already live in the app. The structure is simple on purpose so adding work stays lightweight instead of turning into site maintenance.',
-  },
-  {
-    title: 'Deployment status',
-    body:
-      'The site runs in a LAN-first self-hosted setup today. Public routing has been planned, but it is still intentionally off while the content and presentation get stronger.',
-  },
-  {
-    title: 'What is still intentionally private',
-    body:
-      'Internet-facing deployment, infrastructure details, and other operational mechanics are not the story yet. The goal is to make the work clearer first, then make it public.',
-  },
-  {
-    title: 'Next milestones',
-    body:
-      'Next up: expand project coverage, keep writing down what is learned, and keep tightening the parts that make the work feel credible from the outside.',
-  },
-];
+export default async function NowPage() {
+  const [pageContent, projects] = await Promise.all([getNowContent(), getProjectEntries()]);
+  const projectMap = new Map(projects.map((project) => [project.slug, project]));
 
-export default function NowPage() {
   return (
     <section className="stack page-shell">
-      <p className="eyebrow">Now</p>
-      <h1>What I’m focused on now</h1>
-      <p className="lede">
-        A quick snapshot of the work in motion, what feels solid enough to talk about,
-        and what is still staying behind the curtain for now.
-      </p>
+      <p className="eyebrow">{pageContent.eyebrow}</p>
+      <h1>{pageContent.headline}</h1>
+      <p className="lede">{pageContent.intro}</p>
 
       <div className="stack-tight">
-        <h2>What this is</h2>
-        <p className="lede">
-          This site is the public-facing record of software projects, AI experiments,
-          and technical notes that are still being worked on. It is meant to stay useful,
-          direct, and honest about what is finished versus what is still taking shape.
-        </p>
+        <h2>{pageContent.overview.title}</h2>
+        <p className="lede">{pageContent.overview.body}</p>
       </div>
 
       <div className="project-list">
-        {statusSections.map((section) => (
+        {pageContent.statusSections.map((section) => (
           <article className="project-card" key={section.title}>
             <div className="stack-tight">
               <p className="status-pill">Current</p>
@@ -87,45 +40,38 @@ export default function NowPage() {
       </div>
 
       <div className="stack-tight">
-        <h2>Active projects</h2>
-        <p className="lede">
-          The current set is small on purpose: a few projects that are active, documented,
-          and still moving.
-        </p>
+        <h2>{pageContent.activeProjects.title}</h2>
+        <p className="lede">{pageContent.activeProjects.intro}</p>
       </div>
 
       <ul className="project-list">
-        {activeProjects.map((project) => (
-          <li className="project-card" key={project.href}>
+        {pageContent.activeProjects.items.map((project) => {
+          const projectEntry = projectMap.get(project.slug);
+          const href = `/projects/${project.slug}`;
+          const title = projectEntry?.title ?? project.slug;
+
+          return (
+          <li className="project-card" key={project.slug}>
             <div className="stack-tight">
               <p className="status-pill">Active</p>
               <h2>
-                <Link href={project.href}>{project.title}</Link>
+                <Link href={href}>{title}</Link>
               </h2>
             </div>
             <p>{project.summary}</p>
           </li>
-        ))}
+          );
+        })}
       </ul>
 
       <div className="stack-tight">
-        <h2>Explore from here</h2>
+        <h2>{pageContent.explore.title}</h2>
         <ul className="project-links">
-          <li>
-            <Link href="/projects">Project catalog</Link>
-          </li>
-          <li>
-            <Link href="/projects/personal-site">Personal Site</Link>
-          </li>
-          <li>
-            <Link href="/projects/hn-trend-tracker">HN Trend Tracker</Link>
-          </li>
-          <li>
-            <Link href="/projects/repo-rails">repo-rails</Link>
-          </li>
-          <li>
-            <Link href="/writing">Notes</Link>
-          </li>
+          {pageContent.explore.links.map((link) => (
+            <li key={link.href}>
+              <Link href={link.href}>{link.label}</Link>
+            </li>
+          ))}
         </ul>
       </div>
     </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,45 +1,39 @@
 import Link from 'next/link';
 import { getProjectEntries } from '@/lib/content/projects';
+import { getHomeContent } from '@/lib/content/site';
 import { getWritingEntries } from '@/lib/content/writing';
 
 export default async function HomePage() {
-  const [projects, notes] = await Promise.all([getProjectEntries(), getWritingEntries()]);
+  const [projects, notes, homeContent] = await Promise.all([
+    getProjectEntries(),
+    getWritingEntries(),
+    getHomeContent(),
+  ]);
   const featuredProjects = projects.slice(0, 3);
   const latestNote = notes[0];
 
   return (
     <div className="home-layout">
       <section className="stack hero-panel hero-panel-compact">
-        <p className="eyebrow">Jason Goss</p>
-        <h1>How to get the machine to do work for me.</h1>
-        <p className="lede">
-          I build software, automation, and AI-assisted workflows that turn rough ideas
-          into useful tools. This is the portfolio and notebook for the experiments,
-          systems, and work-in-progress projects worth sharing.
-        </p>
+        <p className="eyebrow">{homeContent.eyebrow}</p>
+        <h1>{homeContent.headline}</h1>
+        <p className="lede">{homeContent.intro}</p>
         <div className="hero-actions">
-          <Link className="button-link" href="/projects">
-            View projects
+          <Link className="button-link" href={homeContent.primaryCta.href}>
+            {homeContent.primaryCta.label}
           </Link>
-          <Link className="subtle-link" href="/writing">
-            Read notes
+          <Link className="subtle-link" href={homeContent.secondaryCta.href}>
+            {homeContent.secondaryCta.label}
           </Link>
         </div>
-        <p className="hero-support">
-          The through-line is practical: use software systems, agent workflows, and AI
-          tools to move more work with less manual drag.
-        </p>
+        <p className="hero-support">{homeContent.support}</p>
       </section>
 
       <section className="home-grid home-grid-balanced">
         <article className="stack feature-panel">
-          <p className="eyebrow">Selected work</p>
-          <h2>Projects first, with the rough edges left visible.</h2>
-          <p>
-            Most of the work here is still in progress. That is the point: the site shows
-            what is actually being built, what is still getting sharper, and what seems
-            worth continuing.
-          </p>
+          <p className="eyebrow">{homeContent.projectsSection.eyebrow}</p>
+          <h2>{homeContent.projectsSection.title}</h2>
+          <p>{homeContent.projectsSection.body}</p>
           <ul className="preview-list">
             {featuredProjects.map((project) => (
               <li className="preview-item" key={project.slug}>
@@ -51,32 +45,29 @@ export default async function HomePage() {
               </li>
             ))}
           </ul>
-          <Link className="subtle-link" href="/projects">
-            Browse the full project list
+          <Link className="subtle-link" href={homeContent.projectsSection.link.href}>
+            {homeContent.projectsSection.link.label}
           </Link>
         </article>
 
         <article className="stack feature-panel">
-          <p className="eyebrow">Notes</p>
-          <h2>Notes on what holds up, what breaks, and what changes next.</h2>
-          <p>
-            The notes section is where decisions, experiments, and implementation details
-            get written down before they disappear into a commit history.
-          </p>
+          <p className="eyebrow">{homeContent.notesSection.eyebrow}</p>
+          <h2>{homeContent.notesSection.title}</h2>
+          <p>{homeContent.notesSection.body}</p>
           {latestNote ? (
             <div className="note-spotlight">
-              <p className="post-date">Latest note</p>
+              <p className="post-date">{homeContent.notesSection.latestNoteLabel}</p>
               <h3>
                 <Link href={`/writing/${latestNote.slug}`}>{latestNote.title}</Link>
               </h3>
               <p>{latestNote.summary}</p>
             </div>
           ) : null}
-          <Link className="subtle-link" href="/writing">
-            Read all notes
+          <Link className="subtle-link" href={homeContent.notesSection.notesLink.href}>
+            {homeContent.notesSection.notesLink.label}
           </Link>
-          <Link className="subtle-link" href="/now">
-            See the current snapshot
+          <Link className="subtle-link" href={homeContent.notesSection.snapshotLink.href}>
+            {homeContent.notesSection.snapshotLink.label}
           </Link>
         </article>
       </section>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,23 +1,25 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getProjectEntries } from '@/lib/content/projects';
+import { getProjectsPageContent } from '@/lib/content/site';
 
-export const metadata: Metadata = {
-  title: 'Projects',
-  description: 'Work-in-progress software, automation, and AI experiments by Jason Goss.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const pageContent = await getProjectsPageContent();
+
+  return {
+    title: pageContent.metadataTitle,
+    description: pageContent.metadataDescription,
+  };
+}
 
 export default async function ProjectsPage() {
-  const projects = await getProjectEntries();
+  const [projects, pageContent] = await Promise.all([getProjectEntries(), getProjectsPageContent()]);
 
   return (
     <section className="stack page-shell">
-      <p className="eyebrow">Projects</p>
-      <h1>Projects in progress</h1>
-      <p className="lede">
-        A working portfolio of tools, experiments, and systems that are getting more
-        useful over time. Some are rough. All of them are real.
-      </p>
+      <p className="eyebrow">{pageContent.eyebrow}</p>
+      <h1>{pageContent.headline}</h1>
+      <p className="lede">{pageContent.intro}</p>
       <ul className="project-list">
         {projects.map((project) => (
           <li className="project-card" key={project.slug}>

--- a/app/writing/page.tsx
+++ b/app/writing/page.tsx
@@ -1,23 +1,25 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { getNotesPageContent } from '@/lib/content/site';
 import { getWritingEntries } from '@/lib/content/writing';
 
-export const metadata: Metadata = {
-  title: 'Notes',
-  description: 'Technical notes and build writeups from ongoing software and AI projects.',
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const pageContent = await getNotesPageContent();
+
+  return {
+    title: pageContent.metadataTitle,
+    description: pageContent.metadataDescription,
+  };
+}
 
 export default async function WritingPage() {
-  const entries = await getWritingEntries();
+  const [entries, pageContent] = await Promise.all([getWritingEntries(), getNotesPageContent()]);
 
   return (
     <section className="stack page-shell">
-      <p className="eyebrow">Notes</p>
-      <h1>Notes from the build process</h1>
-      <p className="lede">
-        Short technical notes, project updates, and writeups on what is working, what is
-        changing, and what is worth keeping from the experiments.
-      </p>
+      <p className="eyebrow">{pageContent.eyebrow}</p>
+      <h1>{pageContent.headline}</h1>
+      <p className="lede">{pageContent.intro}</p>
       <ul className="post-list">
         {entries.map((entry) => (
           <li className="post-card" key={entry.slug}>

--- a/content/site/home.md
+++ b/content/site/home.md
@@ -1,0 +1,23 @@
+---
+eyebrow: Jason Goss
+headline: How to get the machine to do work for me.
+intro: I build software, automation, and AI-assisted workflows that turn rough ideas into useful tools. This is the portfolio and notebook for the experiments, systems, and work-in-progress projects worth sharing.
+primary_cta_label: View projects
+primary_cta_href: /projects
+secondary_cta_label: Read notes
+secondary_cta_href: /writing
+support: The through-line is practical. Use software systems, agent workflows, and AI tools to move more work with less manual drag.
+projects_section_eyebrow: Selected work
+projects_section_title: Projects first, with the rough edges left visible.
+projects_section_body: Most of the work here is still in progress. That is the point. The site shows what is actually being built, what is still getting sharper, and what seems worth continuing.
+projects_section_link_label: Browse the full project list
+projects_section_link_href: /projects
+notes_section_eyebrow: Notes
+notes_section_title: Notes on what holds up, what breaks, and what changes next.
+notes_section_body: The notes section is where decisions, experiments, and implementation details get written down before they disappear into a commit history.
+latest_note_label: Latest note
+notes_section_link_label: Read all notes
+notes_section_link_href: /writing
+snapshot_link_label: See the current snapshot
+snapshot_link_href: /now
+---

--- a/content/site/notes.md
+++ b/content/site/notes.md
@@ -1,0 +1,7 @@
+---
+metadata_title: Notes
+metadata_description: Technical notes and build writeups from ongoing software and AI projects.
+eyebrow: Notes
+headline: Notes from the build process
+intro: Short technical notes, project updates, and writeups on what is working, what is changing, and what is worth keeping from the experiments.
+---

--- a/content/site/now.md
+++ b/content/site/now.md
@@ -1,0 +1,41 @@
+---
+metadata_title: Now
+metadata_description: "A current snapshot of Jason Goss projects, priorities, and work in progress."
+eyebrow: Now
+headline: "What I'm focused on now"
+intro: "A quick snapshot of the work in motion, what feels solid enough to talk about, and what is still staying behind the curtain for now."
+overview_title: What this is
+overview_body: "This site is the public-facing record of software projects, AI experiments, and technical notes that are still being worked on. It is meant to stay useful, direct, and honest about what is finished versus what is still taking shape."
+status_sections:
+  - title: Current focus
+    body: "Right now the focus is sharpening the public presentation, clarifying project pages, tightening notes, and making the work easier to understand without turning the site into a product pitch."
+  - title: What exists now
+    body: "Projects, notes, and the current snapshot are already live in the app. The structure stays deliberately lightweight so adding work does not turn into maintaining a separate publishing system."
+  - title: Deployment status
+    body: "The site runs in a LAN-first self-hosted setup today. Public routing has been planned, but it is still intentionally off while the content and presentation get stronger."
+  - title: What is still intentionally private
+    body: "Internet-facing deployment, infrastructure details, and other operational mechanics are not the story yet. The goal is to make the work clearer first, then make it public."
+  - title: Next milestones
+    body: "Next up is expanding project coverage, continuing to write down what is learned, and tightening the parts that make the work feel credible from the outside."
+active_projects_title: Active projects
+active_projects_intro: "The current set is small on purpose: a few projects that are active, documented, and still moving."
+active_projects:
+  - slug: personal-site
+    summary: "The portfolio and notes hub itself. Right now the work is tightening the public presentation so it feels stable enough to share without pretending it is finished."
+  - slug: hn-trend-tracker
+    summary: "A separate project exploring Hacker News trend collection, analysis, and presentation. It remains one of the active projects documented from this site."
+  - slug: repo-rails
+    summary: "A tooling project for repo structure, policy, and review workflows that supports repeatable setup across project repositories."
+explore_title: Explore from here
+explore_links:
+  - href: /projects
+    label: Project catalog
+  - href: /projects/personal-site
+    label: Personal Site
+  - href: /projects/hn-trend-tracker
+    label: HN Trend Tracker
+  - href: /projects/repo-rails
+    label: repo-rails
+  - href: /writing
+    label: Notes
+---

--- a/content/site/projects.md
+++ b/content/site/projects.md
@@ -1,0 +1,7 @@
+---
+metadata_title: Projects
+metadata_description: Work-in-progress software, automation, and AI experiments by Jason Goss.
+eyebrow: Projects
+headline: Projects in progress
+intro: A working portfolio of tools, experiments, and systems that are getting more useful over time. Some are rough. All of them are real.
+---

--- a/content/site/site.json
+++ b/content/site/site.json
@@ -1,0 +1,36 @@
+{
+  "title": "Jason Goss",
+  "metadataDescription": "Software projects, technical notes, and AI-assisted experiments by Jason Goss.",
+  "headerKicker": "Software projects and notes",
+  "headerSubtitle": "AI-assisted software experiments, project notes, and work in progress aimed at getting useful work done with less manual effort.",
+  "footerTitle": "Jason Goss",
+  "footerSummary": "Projects, notes, and experiments in software, automation, and agent workflows.",
+  "primaryNav": [
+    {
+      "href": "/projects",
+      "label": "Projects"
+    },
+    {
+      "href": "/writing",
+      "label": "Notes"
+    }
+  ],
+  "footerLinks": [
+    {
+      "href": "/projects",
+      "label": "Projects"
+    },
+    {
+      "href": "/writing",
+      "label": "Notes"
+    },
+    {
+      "href": "/now",
+      "label": "Now"
+    },
+    {
+      "href": "https://github.com/jjmgoss/personal-site",
+      "label": "Source"
+    }
+  ]
+}

--- a/lib/content/site.ts
+++ b/lib/content/site.ts
@@ -1,0 +1,256 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+import { cache } from 'react';
+
+export type SiteLink = {
+  href: string;
+  label: string;
+};
+
+export type SiteConfig = {
+  title: string;
+  metadataDescription: string;
+  headerKicker: string;
+  headerSubtitle: string;
+  footerTitle: string;
+  footerSummary: string;
+  primaryNav: SiteLink[];
+  footerLinks: SiteLink[];
+};
+
+export type HomeContent = {
+  eyebrow: string;
+  headline: string;
+  intro: string;
+  primaryCta: SiteLink;
+  secondaryCta: SiteLink;
+  support: string;
+  projectsSection: {
+    eyebrow: string;
+    title: string;
+    body: string;
+    link: SiteLink;
+  };
+  notesSection: {
+    eyebrow: string;
+    title: string;
+    body: string;
+    latestNoteLabel: string;
+    notesLink: SiteLink;
+    snapshotLink: SiteLink;
+  };
+};
+
+export type IndexPageContent = {
+  metadataTitle: string;
+  metadataDescription: string;
+  eyebrow: string;
+  headline: string;
+  intro: string;
+};
+
+export type NowContent = {
+  metadataTitle: string;
+  metadataDescription: string;
+  eyebrow: string;
+  headline: string;
+  intro: string;
+  overview: {
+    title: string;
+    body: string;
+  };
+  statusSections: Array<{
+    title: string;
+    body: string;
+  }>;
+  activeProjects: {
+    title: string;
+    intro: string;
+    items: Array<{
+      slug: string;
+      summary: string;
+    }>;
+  };
+  explore: {
+    title: string;
+    links: SiteLink[];
+  };
+};
+
+const siteDirectory = path.join(process.cwd(), 'content', 'site');
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function requireStringField(data: Record<string, unknown>, field: string, filePath: string): string {
+  const value = data[field];
+
+  if (!isNonEmptyString(value)) {
+    throw new Error(`Invalid site content in ${filePath}: "${field}" is required.`);
+  }
+
+  return value.trim();
+}
+
+function parseLink(value: unknown, filePath: string, field: string): SiteLink {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid site content in ${filePath}: "${field}" must be an object.`);
+  }
+
+  const link = value as Record<string, unknown>;
+  return {
+    href: requireStringField(link, 'href', filePath),
+    label: requireStringField(link, 'label', filePath),
+  };
+}
+
+function parseLinkArray(value: unknown, filePath: string, field: string): SiteLink[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`Invalid site content in ${filePath}: "${field}" must be a non-empty list.`);
+  }
+
+  return value.map((item, index) => parseLink(item, filePath, `${field}[${index}]`));
+}
+
+function parseStringArrayObjects<T>(
+  value: unknown,
+  filePath: string,
+  field: string,
+  mapper: (item: Record<string, unknown>, index: number) => T
+): T[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`Invalid site content in ${filePath}: "${field}" must be a non-empty list.`);
+  }
+
+  return value.map((item, index) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      throw new Error(`Invalid site content in ${filePath}: "${field}[${index}]" must be an object.`);
+    }
+
+    return mapper(item as Record<string, unknown>, index);
+  });
+}
+
+async function readSiteMarkdownFile(fileName: string): Promise<Record<string, unknown>> {
+  const filePath = path.join(siteDirectory, fileName);
+  const rawFile = await readFile(filePath, 'utf8');
+  const { data } = matter(rawFile);
+  return data;
+}
+
+const readSiteJsonConfig = cache(async (): Promise<Record<string, unknown>> => {
+  const filePath = path.join(siteDirectory, 'site.json');
+  const rawFile = await readFile(filePath, 'utf8');
+  return JSON.parse(rawFile) as Record<string, unknown>;
+});
+
+export const getSiteConfig = cache(async (): Promise<SiteConfig> => {
+  const data = await readSiteJsonConfig();
+  const filePath = 'content/site/site.json';
+
+  return {
+    title: requireStringField(data, 'title', filePath),
+    metadataDescription: requireStringField(data, 'metadataDescription', filePath),
+    headerKicker: requireStringField(data, 'headerKicker', filePath),
+    headerSubtitle: requireStringField(data, 'headerSubtitle', filePath),
+    footerTitle: requireStringField(data, 'footerTitle', filePath),
+    footerSummary: requireStringField(data, 'footerSummary', filePath),
+    primaryNav: parseLinkArray(data.primaryNav, filePath, 'primaryNav'),
+    footerLinks: parseLinkArray(data.footerLinks, filePath, 'footerLinks'),
+  };
+});
+
+export const getHomeContent = cache(async (): Promise<HomeContent> => {
+  const data = await readSiteMarkdownFile('home.md');
+  const filePath = 'content/site/home.md';
+
+  return {
+    eyebrow: requireStringField(data, 'eyebrow', filePath),
+    headline: requireStringField(data, 'headline', filePath),
+    intro: requireStringField(data, 'intro', filePath),
+    primaryCta: {
+      label: requireStringField(data, 'primary_cta_label', filePath),
+      href: requireStringField(data, 'primary_cta_href', filePath),
+    },
+    secondaryCta: {
+      label: requireStringField(data, 'secondary_cta_label', filePath),
+      href: requireStringField(data, 'secondary_cta_href', filePath),
+    },
+    support: requireStringField(data, 'support', filePath),
+    projectsSection: {
+      eyebrow: requireStringField(data, 'projects_section_eyebrow', filePath),
+      title: requireStringField(data, 'projects_section_title', filePath),
+      body: requireStringField(data, 'projects_section_body', filePath),
+      link: {
+        label: requireStringField(data, 'projects_section_link_label', filePath),
+        href: requireStringField(data, 'projects_section_link_href', filePath),
+      },
+    },
+    notesSection: {
+      eyebrow: requireStringField(data, 'notes_section_eyebrow', filePath),
+      title: requireStringField(data, 'notes_section_title', filePath),
+      body: requireStringField(data, 'notes_section_body', filePath),
+      latestNoteLabel: requireStringField(data, 'latest_note_label', filePath),
+      notesLink: {
+        label: requireStringField(data, 'notes_section_link_label', filePath),
+        href: requireStringField(data, 'notes_section_link_href', filePath),
+      },
+      snapshotLink: {
+        label: requireStringField(data, 'snapshot_link_label', filePath),
+        href: requireStringField(data, 'snapshot_link_href', filePath),
+      },
+    },
+  };
+});
+
+async function getIndexPageContent(fileName: string): Promise<IndexPageContent> {
+  const data = await readSiteMarkdownFile(fileName);
+  const filePath = `content/site/${fileName}`;
+
+  return {
+    metadataTitle: requireStringField(data, 'metadata_title', filePath),
+    metadataDescription: requireStringField(data, 'metadata_description', filePath),
+    eyebrow: requireStringField(data, 'eyebrow', filePath),
+    headline: requireStringField(data, 'headline', filePath),
+    intro: requireStringField(data, 'intro', filePath),
+  };
+}
+
+export const getProjectsPageContent = cache(async (): Promise<IndexPageContent> => getIndexPageContent('projects.md'));
+
+export const getNotesPageContent = cache(async (): Promise<IndexPageContent> => getIndexPageContent('notes.md'));
+
+export const getNowContent = cache(async (): Promise<NowContent> => {
+  const data = await readSiteMarkdownFile('now.md');
+  const filePath = 'content/site/now.md';
+
+  return {
+    metadataTitle: requireStringField(data, 'metadata_title', filePath),
+    metadataDescription: requireStringField(data, 'metadata_description', filePath),
+    eyebrow: requireStringField(data, 'eyebrow', filePath),
+    headline: requireStringField(data, 'headline', filePath),
+    intro: requireStringField(data, 'intro', filePath),
+    overview: {
+      title: requireStringField(data, 'overview_title', filePath),
+      body: requireStringField(data, 'overview_body', filePath),
+    },
+    statusSections: parseStringArrayObjects(data.status_sections, filePath, 'status_sections', (item) => ({
+      title: requireStringField(item, 'title', filePath),
+      body: requireStringField(item, 'body', filePath),
+    })),
+    activeProjects: {
+      title: requireStringField(data, 'active_projects_title', filePath),
+      intro: requireStringField(data, 'active_projects_intro', filePath),
+      items: parseStringArrayObjects(data.active_projects, filePath, 'active_projects', (item) => ({
+        slug: requireStringField(item, 'slug', filePath),
+        summary: requireStringField(item, 'summary', filePath),
+      })),
+    },
+    explore: {
+      title: requireStringField(data, 'explore_title', filePath),
+      links: parseLinkArray(data.explore_links, filePath, 'explore_links'),
+    },
+  };
+});

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -5,10 +5,12 @@ import matter from 'gray-matter';
 const rootDirectory = process.cwd();
 const projectsDirectory = path.join(rootDirectory, 'content', 'projects');
 const writingDirectory = path.join(rootDirectory, 'content', 'writing');
+const siteDirectory = path.join(rootDirectory, 'content', 'site');
 const publicDirectory = path.join(rootDirectory, 'public');
 
 const PROJECT_STATUSES = new Set(['idea', 'planning', 'active', 'paused', 'shipped', 'archived']);
 const ALLOWED_STATIC_ROUTES = new Set(['/', '/projects', '/writing', '/now']);
+const REQUIRED_SITE_FILES = ['site.json', 'home.md', 'projects.md', 'notes.md', 'now.md'];
 const markdownLinkPattern = /\[[^\]]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
 
 function isNonEmptyString(value) {
@@ -58,6 +60,15 @@ function validateOptionalUrlField(data, field, filePath, errors, scope) {
   }
 
   return value.trim();
+}
+
+function isValidExternalUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
 }
 
 function normalizeDate(value, filePath, errors) {
@@ -115,6 +126,46 @@ function extractInternalLinks(content) {
 
 function normalizeInternalPath(target) {
   return target.split('#')[0].split('?')[0] || '/';
+}
+
+function validateLinkTarget(target, sourceFile, fieldName, knownProjectSlugs, knownWritingSlugs, errors) {
+  if (!isNonEmptyString(target)) {
+    errors.push(`${sourceFile} -> "${fieldName}" must be a non-empty string.`);
+    return;
+  }
+
+  if (target.startsWith('/')) {
+    validateInternalLink(target, sourceFile, knownProjectSlugs, knownWritingSlugs, errors);
+    return;
+  }
+
+  if (!isValidExternalUrl(target)) {
+    errors.push(`${sourceFile} -> "${fieldName}" must be an internal route or a valid http(s) URL.`);
+  }
+}
+
+function requireObjectField(value, field, filePath, errors, scope) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    errors.push(`${scope}: ${filePath} -> "${field}" must be an object.`);
+    return undefined;
+  }
+
+  return value;
+}
+
+function requireObjectArrayField(data, field, filePath, errors, scope, { allowEmpty = false } = {}) {
+  const value = data[field];
+
+  if (!Array.isArray(value) || value.some((item) => !item || typeof item !== 'object' || Array.isArray(item))) {
+    errors.push(`${scope}: ${filePath} -> "${field}" must be a list of objects.`);
+    return [];
+  }
+
+  if (!allowEmpty && value.length === 0) {
+    errors.push(`${scope}: ${filePath} -> "${field}" must not be empty.`);
+  }
+
+  return value;
 }
 
 function validateInternalLink(target, sourceFile, knownProjectSlugs, knownWritingSlugs, errors) {
@@ -264,6 +315,164 @@ async function validateWritingFiles(projectSlugs, errors) {
   return entries;
 }
 
+async function validateSiteFiles(projectSlugs, writingSlugs, errors) {
+  for (const fileName of REQUIRED_SITE_FILES) {
+    const absolutePath = path.join(siteDirectory, fileName);
+    if (!(await fileExists(absolutePath))) {
+      errors.push(`site: required file missing -> content/site/${fileName}.`);
+    }
+  }
+
+  const siteJsonPath = path.join(siteDirectory, 'site.json');
+  if (await fileExists(siteJsonPath)) {
+    let siteConfig;
+    try {
+      siteConfig = JSON.parse(await readFile(siteJsonPath, 'utf8'));
+    } catch (error) {
+      errors.push(`site: content/site/site.json -> failed to parse JSON (${error.message}).`);
+      siteConfig = undefined;
+    }
+
+    if (siteConfig && typeof siteConfig === 'object' && !Array.isArray(siteConfig)) {
+      const filePath = 'content/site/site.json';
+      requireStringField(siteConfig, 'title', filePath, errors, 'site');
+      requireStringField(siteConfig, 'metadataDescription', filePath, errors, 'site');
+      requireStringField(siteConfig, 'headerKicker', filePath, errors, 'site');
+      requireStringField(siteConfig, 'headerSubtitle', filePath, errors, 'site');
+      requireStringField(siteConfig, 'footerTitle', filePath, errors, 'site');
+      requireStringField(siteConfig, 'footerSummary', filePath, errors, 'site');
+
+      const primaryNav = requireObjectArrayField(siteConfig, 'primaryNav', filePath, errors, 'site');
+      primaryNav.forEach((item, index) => {
+        requireStringField(item, 'label', filePath, errors, 'site');
+        const href = requireStringField(item, 'href', filePath, errors, 'site');
+        if (href) {
+          validateLinkTarget(href, filePath, `primaryNav[${index}].href`, projectSlugs, writingSlugs, errors);
+        }
+      });
+
+      const footerLinks = requireObjectArrayField(siteConfig, 'footerLinks', filePath, errors, 'site');
+      footerLinks.forEach((item, index) => {
+        requireStringField(item, 'label', filePath, errors, 'site');
+        const href = requireStringField(item, 'href', filePath, errors, 'site');
+        if (href) {
+          validateLinkTarget(href, filePath, `footerLinks[${index}].href`, projectSlugs, writingSlugs, errors);
+        }
+      });
+    } else if (siteConfig !== undefined) {
+      errors.push('site: content/site/site.json -> root value must be an object.');
+    }
+  }
+
+  const siteMarkdownFiles = ['home.md', 'projects.md', 'notes.md', 'now.md'];
+
+  for (const fileName of siteMarkdownFiles) {
+    const absolutePath = path.join(siteDirectory, fileName);
+    if (!(await fileExists(absolutePath))) {
+      continue;
+    }
+
+    const rawFile = await readFile(absolutePath, 'utf8');
+    const { data, content } = matter(rawFile);
+    const filePath = `content/site/${fileName}`;
+
+    if (fileName === 'home.md') {
+      const requiredFields = [
+        'eyebrow',
+        'headline',
+        'intro',
+        'primary_cta_label',
+        'primary_cta_href',
+        'secondary_cta_label',
+        'secondary_cta_href',
+        'support',
+        'projects_section_eyebrow',
+        'projects_section_title',
+        'projects_section_body',
+        'projects_section_link_label',
+        'projects_section_link_href',
+        'notes_section_eyebrow',
+        'notes_section_title',
+        'notes_section_body',
+        'latest_note_label',
+        'notes_section_link_label',
+        'notes_section_link_href',
+        'snapshot_link_label',
+        'snapshot_link_href',
+      ];
+
+      for (const field of requiredFields) {
+        requireStringField(data, field, fileName, errors, 'site');
+      }
+
+      for (const field of [
+        'primary_cta_href',
+        'secondary_cta_href',
+        'projects_section_link_href',
+        'notes_section_link_href',
+        'snapshot_link_href',
+      ]) {
+        const href = toTrimmedString(data[field]);
+        if (href) {
+          validateLinkTarget(href, filePath, field, projectSlugs, writingSlugs, errors);
+        }
+      }
+    }
+
+    if (fileName === 'projects.md' || fileName === 'notes.md') {
+      for (const field of ['metadata_title', 'metadata_description', 'eyebrow', 'headline', 'intro']) {
+        requireStringField(data, field, fileName, errors, 'site');
+      }
+    }
+
+    if (fileName === 'now.md') {
+      for (const field of [
+        'metadata_title',
+        'metadata_description',
+        'eyebrow',
+        'headline',
+        'intro',
+        'overview_title',
+        'overview_body',
+        'active_projects_title',
+        'active_projects_intro',
+        'explore_title',
+      ]) {
+        requireStringField(data, field, fileName, errors, 'site');
+      }
+
+      const statusSections = requireObjectArrayField(data, 'status_sections', fileName, errors, 'site');
+      statusSections.forEach((section, index) => {
+        requireStringField(section, 'title', fileName, errors, 'site');
+        requireStringField(section, 'body', fileName, errors, 'site');
+        requireObjectField(section, `status_sections[${index}]`, fileName, errors, 'site');
+      });
+
+      const activeProjects = requireObjectArrayField(data, 'active_projects', fileName, errors, 'site');
+      activeProjects.forEach((project, index) => {
+        const slug = requireStringField(project, 'slug', fileName, errors, 'site');
+        requireStringField(project, 'summary', fileName, errors, 'site');
+        if (slug && !projectSlugs.has(slug)) {
+          errors.push(`site: ${fileName} -> active_projects[${index}].slug "${slug}" does not exist in content/projects.`);
+        }
+      });
+
+      const exploreLinks = requireObjectArrayField(data, 'explore_links', fileName, errors, 'site');
+      exploreLinks.forEach((link, index) => {
+        requireStringField(link, 'label', fileName, errors, 'site');
+        const href = requireStringField(link, 'href', fileName, errors, 'site');
+        if (href) {
+          validateLinkTarget(href, filePath, `explore_links[${index}].href`, projectSlugs, writingSlugs, errors);
+        }
+      });
+    }
+
+    for (const target of extractInternalLinks(content)) {
+      validateInternalLink(target, filePath, projectSlugs, writingSlugs, errors);
+    }
+  }
+}
+
 async function main() {
   const errors = [];
 
@@ -271,6 +480,8 @@ async function main() {
   const projectSlugs = new Set(projects.map((project) => project.slug).filter(Boolean));
   const writingEntries = await validateWritingFiles(projectSlugs, errors);
   const writingSlugs = new Set(writingEntries.map((entry) => entry.slug).filter(Boolean));
+
+  await validateSiteFiles(projectSlugs, writingSlugs, errors);
 
   for (const project of projects) {
     for (const target of extractInternalLinks(project.content)) {
@@ -294,7 +505,7 @@ async function main() {
   }
 
   console.log(
-    `Content validation passed for ${projects.length} project file(s) and ${writingEntries.length} writing file(s).`
+    `Content validation passed for ${projects.length} project file(s), ${writingEntries.length} writing file(s), and ${REQUIRED_SITE_FILES.length} site file(s).`
   );
 }
 


### PR DESCRIPTION
## Summary
Move common public-facing site copy out of React components and into editable files under content/site/.

## Linked Issue Or Reference
Closes #36

## What Changed
- added a new content/site/ convention with site.json, home.md, projects.md, 
otes.md, and 
ow.md
- added lib/content/site.ts to load typed site config and page copy at build time
- updated the shared layout, homepage, projects index, notes index, and now page to render from site content instead of hardcoded paragraphs
- extended 
pm run validate:content to validate site-level content files, required fields, and internal/external link targets
- documented the new copy-editing workflow in README.md

## Verification
- 
pm run validate:content ✅ passed: content validation passed for 3 project file(s), 1 writing file(s), and 5 site file(s)
- 
pm run build ✅ passed
- 
pm run lint not run because no lint script exists in package.json
- manually verified /, /projects, /writing, and /now locally via 
pm run dev
- git diff --stat reviewed before commit
- git status --short reviewed before commit

## Risk And Deployment Impact
No deployment behavior change. Risk is limited to site copy loading and validation for the new content/site/ files.

## Reviewer Focus
- confirm the new content/site/ structure is easy to edit without touching TSX
- confirm the moved homepage, index-page, shared-layout, and now-page copy still reads correctly
- confirm the new validation errors are readable and the link checks are appropriately strict

## Follow-Ups
- consider moving any additional frequently edited route metadata or small public copy into content/site/ only if it proves useful