### PR TITLE
[agent-task] Add Autonomous Product Development project page

### DIFF
--- a/content/projects/autonomous-product-development.md
+++ b/content/projects/autonomous-product-development.md
@@ -1,0 +1,46 @@
+---
+title: Autonomous Product Development
+slug: autonomous-product-development
+status: active
+summary: AI-assisted research and build workflow for generating, evaluating, documenting, and selectively prototyping small product ideas.
+stack:
+  - Python
+  - FastAPI
+  - SQLite
+  - Jinja
+  - Markdown
+  - Agent workflows
+next_milestone: Tighten the discovery-to-prototype workflow and keep improving the evidence, review, and planning surfaces for small product experiments.
+repo_url: https://github.com/jjmgoss/autonomous-product-development
+live_url:
+docs_url: https://github.com/jjmgoss/autonomous-product-development/tree/main/docs
+---
+
+`autonomous-product-development` is a work-in-progress framework for using
+AI-assisted research and development workflows to investigate small product
+ideas before overbuilding them.
+
+The core idea is simple: start from a direct problem or market question, use an
+agent-assisted process to gather evidence, compare candidate product directions,
+document the reasoning, and only move toward implementation when the case is
+good enough to justify it.
+
+The project exists because a lot of product exploration fails long before code
+quality becomes the real problem. Weak ideas, vague demand, and poor narrowing
+usually do more damage than the implementation details. This workflow is an
+attempt to make those early decisions more explicit and easier to review.
+
+What it is trying to learn:
+
+- how far AI-assisted research can go before confidence stops matching evidence
+- how to evaluate small product ideas without turning every investigation into a full build
+- how to document the path from rough intent to prototype or no-go decision
+- what a practical solo-operator workflow looks like for AI-assisted product experiments
+
+The current status is active, but still experimental. It is not a fully
+autonomous system and it should not be treated like one. The goal is to build a
+more reliable research-and-build workflow, not to pretend the human judgment
+layer has disappeared.
+
+If it works, the value is in helping narrow ideas, record tradeoffs, and decide
+which small product experiments are actually worth taking into a prototype.

--- a/content/site/now.md
+++ b/content/site/now.md
@@ -22,6 +22,8 @@ active_projects_intro: "The current set is small on purpose: a few projects that
 active_projects:
   - slug: personal-site
     summary: "The portfolio and notes hub itself. Right now the work is tightening the public presentation so it feels stable enough to share without pretending it is finished."
+  - slug: autonomous-product-development
+    summary: "An AI-assisted research and build workflow for evaluating small product ideas, documenting the reasoning, and deciding when a prototype is actually worth building."
   - slug: hn-trend-tracker
     summary: "A separate project exploring Hacker News trend collection, analysis, and presentation. It remains one of the active projects documented from this site."
   - slug: repo-rails
@@ -32,6 +34,8 @@ explore_links:
     label: Project catalog
   - href: /projects/personal-site
     label: Personal Site
+  - href: /projects/autonomous-product-development
+    label: Autonomous Product Development
   - href: /projects/hn-trend-tracker
     label: HN Trend Tracker
   - href: /projects/repo-rails


### PR DESCRIPTION
## Summary
Add Autonomous Product Development to the project catalog as an honest work-in-progress project and include it in the current active-projects list on the Now page.

## Linked Issue Or Reference
Closes #42

## What Changed
- added content/projects/autonomous-product-development.md with project frontmatter and grounded descriptive copy
- described the project as an AI-assisted research-and-build workflow for evaluating small product ideas without overstating autonomy
- updated content/site/now.md so the project appears in the active-projects list and explore links
- left public routing, live URLs, screenshots, and infrastructure changes out of scope

## Verification
- 
pm run validate:content ✅ passed: content validation passed for 4 project file(s), 1 writing file(s), and 5 site file(s)
- 
pm run build ✅ passed
- 
pm run test:site not run because no 	est:site script exists in package.json
- git diff --stat reviewed before commit
- git status reviewed before commit
- manually verified /projects, /projects/autonomous-product-development, and /now

## Risk And Deployment Impact
Content-only change. No deployment behavior change; normal static app redeploy after merge.

## Reviewer Focus
- confirm the new project copy is grounded and avoids hype or autonomy claims that go beyond the current state
- confirm the selected stack and next-milestone framing feel accurate for the repository today
- confirm the /now update fits the current active-projects section cleanly

## Follow-Ups
- add related notes later if the APD workflow produces public writeups worth linking from the site