### PR TITLE
[agent-task] Add Playwright smoke tests for public routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,11 @@ jobs:
       - name: Build app
         if: ${{ hashFiles('package.json') != '' }}
         run: npm run build
+
+      - name: Install Playwright browser
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npx playwright install --with-deps chromium
+
+      - name: Run site smoke tests
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npm run test:site

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pnpm-debug.log*
 .env
 .env.local
 .env*.local
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ Validate content frontmatter, screenshot references, and simple internal content
 npm run validate:content
 ```
 
+Run the public-route smoke tests:
+
+```powershell
+npm run test:site
+```
+
+For a line-by-line test report:
+
+```powershell
+npm run test:site -- --reporter=list
+```
+
 Start the production server after a build:
 
 ```powershell
@@ -158,3 +170,23 @@ After editing content, run:
 npm run validate:content
 npm run build
 ```
+
+## Route Smoke Tests
+
+The repository includes lightweight Playwright smoke tests for the main public routes.
+
+The tests use the built app with Playwright `webServer`, so the normal local flow is:
+
+```powershell
+npm run build
+npm run test:site
+```
+
+If Playwright browsers are not installed yet on the local machine, install Chromium once with:
+
+```powershell
+npx playwright install chromium
+```
+
+These smoke tests are intended to catch route render failures, broken primary navigation,
+and broken image loading on public pages. They are not screenshot-diff or visual regression tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-markdown": "^10.1.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.52.0",
         "@types/node": "^22.14.0",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
@@ -691,6 +692,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1001,6 +1018,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/gray-matter": {
@@ -1872,6 +1903,38 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/postcss": {
       "version": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "validate:content": "node scripts/validate-content.mjs",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test:site": "playwright test"
   },
   "dependencies": {
     "gray-matter": "^4.0.3",
@@ -16,6 +17,7 @@
     "react-markdown": "^10.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "@types/node": "^22.14.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://127.0.0.1:3000',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run start -- --hostname 127.0.0.1 --port 3000',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/tests/site-smoke.spec.ts
+++ b/tests/site-smoke.spec.ts
@@ -1,0 +1,167 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import matter from 'gray-matter';
+import { expect, test, type Page } from '@playwright/test';
+
+const repoRoot = path.resolve(__dirname, '..');
+
+type SiteConfig = {
+  title: string;
+  primaryNav: Array<{
+    href: string;
+    label: string;
+  }>;
+};
+
+function readJsonFile<T>(relativePath: string): T {
+  const filePath = path.join(repoRoot, relativePath);
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+}
+
+function readFrontmatter(relativePath: string): Record<string, unknown> {
+  const filePath = path.join(repoRoot, relativePath);
+  const rawFile = fs.readFileSync(filePath, 'utf8');
+  return matter(rawFile).data;
+}
+
+const siteConfig = readJsonFile<SiteConfig>('content/site/site.json');
+const homeContent = readFrontmatter('content/site/home.md');
+const projectsPageContent = readFrontmatter('content/site/projects.md');
+const notesPageContent = readFrontmatter('content/site/notes.md');
+const nowPageContent = readFrontmatter('content/site/now.md');
+const personalSiteProject = readFrontmatter('content/projects/personal-site.md');
+const autonomousProductDevelopmentPath = path.join(
+  repoRoot,
+  'content/projects/autonomous-product-development.md'
+);
+const autonomousProductDevelopment = fs.existsSync(autonomousProductDevelopmentPath)
+  ? readFrontmatter('content/projects/autonomous-product-development.md')
+  : undefined;
+
+async function assertNoObviousAppError(page: Page) {
+  await expect(page.locator('body')).not.toContainText(/Application error|Unhandled Runtime Error/i);
+}
+
+async function assertLoadedImages(page: Page) {
+  const images = page.locator('img');
+  const count = await images.count();
+
+  for (let index = 0; index < count; index += 1) {
+    const image = images.nth(index);
+    await image.scrollIntoViewIfNeeded();
+
+    await expect
+      .poll(async () => {
+        return image.evaluate((node) => {
+          const img = node as HTMLImageElement;
+
+          if (!img.complete) {
+            return 'pending';
+          }
+
+          return img.naturalWidth > 0 && img.naturalHeight > 0 ? 'loaded' : 'broken';
+        });
+      })
+      .toBe('loaded');
+  }
+}
+
+async function assertRoute(page: Page, route: string, expectedHeading: string, expectedTitleFragment: string) {
+  const response = await page.goto(route, { waitUntil: 'networkidle' });
+
+  expect(response).not.toBeNull();
+  expect(response?.ok(), `Expected ${route} to load successfully.`).toBeTruthy();
+
+  await assertNoObviousAppError(page);
+  await expect(page.getByRole('heading', { level: 1, name: expectedHeading })).toBeVisible();
+  await expect(page.locator('body')).toContainText(siteConfig.title);
+
+  const pageTitle = await page.title();
+  expect(pageTitle.trim().length).toBeGreaterThan(0);
+  expect(pageTitle).toContain(expectedTitleFragment);
+
+  await assertLoadedImages(page);
+}
+
+test.describe('public route smoke tests', () => {
+  test('homepage renders and primary navigation works', async ({ page }) => {
+    await assertRoute(
+      page,
+      '/',
+      String(homeContent.headline),
+      siteConfig.title
+    );
+
+    const navigation = page.getByRole('navigation', { name: 'Primary' });
+    const projectsLink = navigation.getByRole('link', {
+      name: siteConfig.primaryNav.find((item) => item.href === '/projects')?.label ?? 'Projects',
+    });
+    const notesLink = navigation.getByRole('link', {
+      name: siteConfig.primaryNav.find((item) => item.href === '/writing')?.label ?? 'Notes',
+    });
+
+    await expect(projectsLink).toBeVisible();
+    await expect(notesLink).toBeVisible();
+
+    await projectsLink.click();
+    await expect(page).toHaveURL(/\/projects$/);
+    await expect(page.getByRole('heading', { level: 1, name: String(projectsPageContent.headline) })).toBeVisible();
+
+    await page.goto('/', { waitUntil: 'networkidle' });
+    await notesLink.click();
+    await expect(page).toHaveURL(/\/writing$/);
+    await expect(page.getByRole('heading', { level: 1, name: String(notesPageContent.headline) })).toBeVisible();
+  });
+
+  test('projects index renders', async ({ page }) => {
+    await assertRoute(
+      page,
+      '/projects',
+      String(projectsPageContent.headline),
+      String(projectsPageContent.metadata_title)
+    );
+  });
+
+  test('personal-site project page renders without broken images', async ({ page }) => {
+    await assertRoute(
+      page,
+      '/projects/personal-site',
+      String(personalSiteProject.title),
+      String(personalSiteProject.title)
+    );
+
+    await expect(page.locator('body')).toContainText(String(personalSiteProject.summary));
+    await expect(page.locator('text=Current visual snapshot')).toHaveCount(0);
+  });
+
+  test('writing index renders', async ({ page }) => {
+    await assertRoute(
+      page,
+      '/writing',
+      String(notesPageContent.headline),
+      String(notesPageContent.metadata_title)
+    );
+  });
+
+  test('now page renders', async ({ page }) => {
+    await assertRoute(
+      page,
+      '/now',
+      String(nowPageContent.headline),
+      String(nowPageContent.metadata_title)
+    );
+  });
+
+  if (autonomousProductDevelopment) {
+    test('autonomous product development page renders', async ({ page }) => {
+      await assertRoute(
+        page,
+        '/projects/autonomous-product-development',
+        String(autonomousProductDevelopment.title),
+        String(autonomousProductDevelopment.title)
+      );
+
+      await expect(page.locator('body')).toContainText(String(autonomousProductDevelopment.summary));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
Add lightweight Playwright smoke tests for the main public routes so route health, navigation, and image loading checks can run repeatably in local development and CI.

## Linked Issue Or Reference
Closes #37

## What Changed
- added Playwright with a small production-server-backed setup in playwright.config.ts
- added 	ests/site-smoke.spec.ts covering /, /projects, /projects/personal-site, /writing, /now, and /projects/autonomous-product-development
- made the smoke tests read route headings and site identity from the existing content files so they are less brittle against normal content edits
- added the 	est:site npm script and installed @playwright/test
- updated CI to install Chromium and run 
pm run test:site after content validation and build
- updated README.md with local Playwright setup and run instructions
- ignored Playwright report/output directories in .gitignore

## Verification
- 
px playwright install chromium ✅ installed Chromium locally
- 
pm run validate:content ✅ passed: content validation passed for 4 project file(s), 1 writing file(s), and 5 site file(s)
- 
pm run build ✅ passed
- 
pm run test:site ✅ passed: 6 tests passed
- 
pm run test:site -- --reporter=list ✅ passed: 6 tests passed with list reporter
- 
pm run lint not run because no lint script exists in package.json
- git diff --stat reviewed before commit
- git status reviewed before commit

## Risk And Deployment Impact
No runtime deployment behavior change. CI will take a bit longer because it now installs Chromium and runs Playwright smoke tests.

## Reviewer Focus
- confirm the Playwright checks are strong enough to catch route regressions without being brittle against normal copy edits
- confirm the webServer setup using the built app (
pm run start) is the right reliability tradeoff for this repo
- confirm the CI ordering and browser install step are as small as possible while still reliable

## Follow-Ups
- consider adding a second small smoke test for project-detail navigation if later route complexity increases