### PR TITLE
[deployment] Configure Cloudflare Tunnel docs for lab.jjmgoss.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ docker compose stop
 
 For the first Synology LAN deployment path, see `docs/synology-lan-deployment.md`.
 
+For public-safe setup planning for the first Cloudflare Tunnel hostname, see `docs/cloudflare-tunnel-setup.md`.
+
 For rollback planning before any future Cloudflare Tunnel public exposure, see `docs/cloudflare-tunnel-rollback.md`.
 
 After SSHing into the Synology repo checkout, the normal LAN update command is `./scripts/deploy-synology-lan.sh`.

--- a/docs/cloudflare-tunnel-rollback.md
+++ b/docs/cloudflare-tunnel-rollback.md
@@ -10,6 +10,8 @@ The goal is to return safely to LAN-only operation without deleting the local ap
 
 This document is planning and rollback guidance only.
 
+For the corresponding setup-side planning guide, see `docs/cloudflare-tunnel-setup.md`.
+
 It does not:
 
 - create a Cloudflare Tunnel

--- a/docs/cloudflare-tunnel-setup.md
+++ b/docs/cloudflare-tunnel-setup.md
@@ -1,0 +1,220 @@
+# Cloudflare Tunnel Setup For lab.jjmgoss.com
+
+## Goal And Scope
+
+This guide documents the intended setup shape for exposing the `personal-site` app publicly at `lab.jjmgoss.com` through Cloudflare Tunnel.
+
+The goal is to prepare the repository for safe human execution without committing secrets or changing the existing Synology LAN deployment baseline.
+
+This guide does not:
+
+- create a real Cloudflare Tunnel
+- create DNS records
+- enter a tunnel token
+- expose the site publicly from this repository change
+- modify the working LAN deployment behavior by default
+
+## Baseline
+
+The current baseline remains the existing Synology LAN deployment.
+
+Public-safe current shape:
+
+```text
+http://<synology-host>:<app-port>
+```
+
+The Cloudflare Tunnel path should be treated as a separate runtime concern layered on top of that working baseline.
+
+The fallback remains LAN-only operation.
+
+If public routing is disabled, the expected fallback is still:
+
+```text
+http://<synology-host>:<app-port>
+```
+
+For rollback and disable steps, see `docs/cloudflare-tunnel-rollback.md`.
+
+## Intended Hostname
+
+The first intended public hostname is:
+
+```text
+lab.jjmgoss.com
+```
+
+This guide is scoped only to that hostname.
+
+It does not decide or route:
+
+- `jjmgoss.com`
+- other project subdomains
+- Synology DSM
+- any unrelated app or admin surface
+
+## Recommended Tunnel Shape
+
+The preferred setup is:
+
+```text
+Public browser
+  -> https://lab.jjmgoss.com
+  -> Cloudflare
+  -> Cloudflare Tunnel
+  -> http://<origin-service>:<app-port>
+  -> personal-site app
+```
+
+The tunnel should map only the intended public hostname to only the `personal-site` origin.
+
+Do not route:
+
+- Synology DSM
+- SSH
+- admin interfaces
+- databases
+- other containers
+- development servers
+
+## Where The Tunnel Should Run
+
+The recommended posture is to run the tunnel as a separate runtime concern from the app itself.
+
+That means:
+
+- keep the existing `personal-site` app container responsible only for the site
+- run `cloudflared` separately, such as a sidecar container or equivalent Synology-managed runtime
+- keep the tunnel token and any Cloudflare-specific values outside the repo
+
+This keeps public routing easier to disable without changing the app container itself.
+
+## How The Tunnel Should Reach The Local App Origin
+
+The tunnel should point to the existing app origin, not to Synology DSM and not to a development server.
+
+Public-safe placeholder shape:
+
+```text
+http://<origin-service>:<app-port>
+```
+
+Examples of acceptable placeholder meanings:
+
+- `<origin-service>` could be the compose service name for the site
+- `<app-port>` should be the app's internal or intended origin port
+
+Do not commit the real internal hostname, container IP, Synology LAN hostname, or any other private network detail if it is not already intentionally public.
+
+## Human-Gated Setup Steps
+
+The following steps require a human operator and should not be treated as completed by this repository change:
+
+1. Create or select the Cloudflare Tunnel for `<tunnel-name>`.
+2. Create or confirm the hostname route for `lab.jjmgoss.com`.
+3. Obtain the tunnel token or credentials outside the repo.
+4. Install or run `cloudflared` in the approved Synology/runtime location.
+5. Enter the real token or credentials outside the repository.
+6. Verify public routing from outside the LAN.
+7. Disable public access immediately if the result is not as expected.
+
+These are operator actions, not repository-side automated steps.
+
+## Human-Only Cloudflare Dashboard Actions
+
+Use Cloudflare dashboard actions only as a human-gated deployment step.
+
+Expected operator responsibilities include:
+
+- choosing or confirming `<cloudflare-account>`
+- creating or selecting `<tunnel-name>`
+- adding the hostname route for `lab.jjmgoss.com`
+- confirming the tunnel points only to the `personal-site` origin
+- verifying HTTPS at the public hostname
+
+Do not commit screenshots, copied dashboard values, tunnel IDs, or account IDs.
+
+## Safe Placeholder CLI Examples
+
+If a human later uses CLI-based setup, examples must remain placeholder-safe.
+
+Example placeholder-only shapes:
+
+```text
+cloudflared tunnel create <tunnel-name>
+cloudflared tunnel route dns <tunnel-name> lab.jjmgoss.com
+cloudflared tunnel run <tunnel-name>
+```
+
+These are documentation examples only.
+
+Do not commit real tokens, IDs, or generated config values.
+
+## Safe Template Files
+
+This repository includes example-only templates under `docs/examples/`.
+
+Use them as references only:
+
+- `docs/examples/cloudflared-compose.example.yml`
+- `docs/examples/cloudflared-config.example.yml`
+
+They are intentionally non-runnable until a human fills in real values outside the repository.
+
+## Verification Checklist
+
+Before enabling public exposure, confirm:
+
+- the LAN app is healthy before tunnel setup
+- the tunnel maps only `lab.jjmgoss.com`
+- the tunnel origin points only to the `personal-site` app
+- no DSM, admin, or unrelated service ports are routed
+- HTTPS works at the public hostname
+- the homepage loads publicly
+- `/projects` loads publicly
+- `/writing` loads publicly
+- `/now` loads publicly
+- the theme toggle works publicly
+- no private LAN URLs appear in rendered pages
+- the rollback path is understood before exposing
+
+## Rollback Checklist
+
+Before enabling the tunnel, review the rollback guide:
+
+- `docs/cloudflare-tunnel-rollback.md`
+
+At minimum, the operator should know how to:
+
+- temporarily disable public exposure
+- fully remove the public hostname route later if needed
+- confirm the site still works on the LAN
+
+## What Not To Commit
+
+Never commit:
+
+- Cloudflare tunnel tokens
+- tunnel IDs
+- Cloudflare account IDs
+- real DNS record IDs
+- internal IP addresses
+- private hostnames
+- usernames
+- local filesystem paths
+- Synology DSM URLs
+- screenshots of Cloudflare or Synology dashboards
+- `.env` contents or secrets of any kind
+
+Keep all examples placeholder-safe.
+
+## Future Follow-Ups
+
+Later work may add:
+
+- a human-approved runtime recipe for `cloudflared` on Synology
+- exact operator commands once the runtime location is chosen
+- public verification notes after the first exposure is intentionally enabled
+- route-specific troubleshooting if the first public hostname behaves differently than LAN access
+
+This guide should remain aligned with the rollback model in `docs/cloudflare-tunnel-rollback.md`.

--- a/docs/deployment-strategy.md
+++ b/docs/deployment-strategy.md
@@ -139,6 +139,8 @@ The chosen first public routing model is Cloudflare Tunnel for `lab.jjmgoss.com`
 
 The current LAN-only Synology deployment remains the baseline until that later implementation work is explicitly approved.
 
+The current public-safe setup guide for that path is `docs/cloudflare-tunnel-setup.md`.
+
 Before enabling any future Cloudflare Tunnel route, use `docs/cloudflare-tunnel-rollback.md` as the planning reference for temporary disablement and full rollback back to LAN-only operation.
 
 ### Option 1: Cloudflare Tunnel

--- a/docs/examples/cloudflared-compose.example.yml
+++ b/docs/examples/cloudflared-compose.example.yml
@@ -1,0 +1,17 @@
+# Example only. Do not run this file without replacing placeholders outside the repository.
+# Do not commit real tunnel tokens, IDs, hostnames, or private origin details.
+
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    command:
+      - tunnel
+      - run
+      - --token
+      - ${CLOUDFLARED_TUNNEL_TOKEN}
+    environment:
+      CLOUDFLARED_TUNNEL_TOKEN: <tunnel-token>
+
+# Intended placeholder-only relationship:
+# https://lab.jjmgoss.com -> Cloudflare Tunnel -> http://<origin-service>:<app-port>

--- a/docs/examples/cloudflared-config.example.yml
+++ b/docs/examples/cloudflared-config.example.yml
@@ -1,0 +1,10 @@
+# Example only. Placeholder values must be replaced outside the repository.
+# Do not commit real tunnel IDs, account IDs, hostnames, or private origin values.
+
+tunnel: <tunnel-name>
+credentials-file: /run/secrets/<tunnel-name>.json
+
+ingress:
+  - hostname: lab.jjmgoss.com
+    service: http://<origin-service>:<app-port>
+  - service: http_status:404

--- a/docs/public-routing-decision.md
+++ b/docs/public-routing-decision.md
@@ -77,6 +77,8 @@ This PR does not create DNS records, tunnel routes, or origin mappings.
 
 The chosen first model is Cloudflare Tunnel.
 
+The current public-safe setup guide for this path is `docs/cloudflare-tunnel-setup.md`.
+
 Planned future routing shape, still placeholder-safe:
 
 ```text
@@ -234,6 +236,8 @@ http://<synology-lan-host>:<configured-lan-port>
 The first public routing model should be easy to disable.
 
 The current rollback planning guide is `docs/cloudflare-tunnel-rollback.md`.
+
+The current setup planning guide is `docs/cloudflare-tunnel-setup.md`.
 
 Desired rollback posture:
 


### PR DESCRIPTION
## Summary
Add a public-safe Cloudflare Tunnel setup guide for lab.jjmgoss.com, plus example-only templates and small cross-links from the existing deployment docs.

## Linked Issue Or Reference
Closes #27

## What Changed
- added docs/cloudflare-tunnel-setup.md covering the intended hostname, baseline LAN fallback, recommended tunnel shape, origin-routing posture, human-gated actions, verification, rollback link, and commit-safety boundaries
- added example-only placeholder templates in docs/examples/cloudflared-compose.example.yml and docs/examples/cloudflared-config.example.yml
- added small cross-links from README.md, docs/deployment-strategy.md, docs/public-routing-decision.md, and docs/cloudflare-tunnel-rollback.md
- kept the existing docker-compose.yml and Synology LAN deployment behavior unchanged

## Verification
- 
pm run validate:content ✅ passed: content validation passed for 4 project file(s), 1 writing file(s), and 5 site file(s)
- 
pm run build ✅ passed
- 
pm run test:site ✅ passed: 7 tests passed
- git diff --stat ✅ reviewed before commit
- git status ✅ reviewed before commit
- 
pm run lint not run because no lint script exists in package.json
- local note: the first 
pm run test:site attempt picked up the recurring .next artifact problem (endor-chunks/esprima.js missing during 
ext start); removing .next, rebuilding, and rerunning the same test resolved it without code changes

## Risk And Deployment Impact
Documentation and example-template change only. No real Cloudflare actions were performed. No DNS, no tunnel token, no live secret, and no Synology/Docker deployment behavior was changed.

## Reviewer Focus
- confirm the setup guide is explicit about human-gated actions and does not imply public exposure was completed
- confirm the guide keeps the tunnel as a separate runtime concern from the app container
- confirm the example templates are clearly placeholder-only and safe to keep in the repo

## Human-Gated Follow-Up Steps
- create or select the Cloudflare Tunnel for the intended hostname
- enter real token or credentials outside the repository
- create the lab.jjmgoss.com hostname route in Cloudflare
- install or run cloudflared in the approved Synology/runtime location
- verify public access from outside the LAN
- disable public access immediately if anything looks wrong, following docs/cloudflare-tunnel-rollback.md

## Follow-Ups
- once the human operator chooses the exact Synology/runtime location for cloudflared, add a tighter operator runbook that still keeps tokens and private origin values out of the repo