### PR TITLE
Polish repeated public site copy

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,10 +56,7 @@ export default async function RootLayout({
             </header>
             <main className="site-main">{children}</main>
             <footer className="site-footer">
-              <div>
-                <p className="site-footer-title">{siteConfig.footerTitle}</p>
-                <p className="site-footer-copy">{siteConfig.footerSummary}</p>
-              </div>
+              {siteConfig.footerSummary ? <p className="site-footer-copy">{siteConfig.footerSummary}</p> : null}
               <ul className="site-footer-links">
                 {siteConfig.footerLinks.map((item) => (
                   <li key={item.href}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ export default async function HomePage() {
     getWritingEntries(),
     getHomeContent(),
   ]);
-  const featuredProjects = projects.slice(0, 3);
+  const featuredProjects = projects.slice(0, 2);
   const latestNote = notes[0];
 
   return (
@@ -40,7 +40,6 @@ export default async function HomePage() {
                   <Link href={`/projects/${project.slug}`}>{project.title}</Link>
                   <span>{project.status}</span>
                 </div>
-                <p>{project.summary}</p>
               </li>
             ))}
           </ul>
@@ -59,7 +58,6 @@ export default async function HomePage() {
               <h3>
                 <Link href={`/writing/${latestNote.slug}`}>{latestNote.title}</Link>
               </h3>
-              <p>{latestNote.summary}</p>
             </div>
           ) : null}
           <Link className="subtle-link" href={homeContent.notesSection.notesLink.href}>

--- a/content/projects/personal-site.md
+++ b/content/projects/personal-site.md
@@ -16,4 +16,4 @@ docs_url: https://github.com/jjmgoss/personal-site/tree/main/docs
 
 This is what you're looking at right now.
 
-Simple front end, basically no backend, description of some of my personal projects.
+It is a small front end, basically no backend, and just enough structure to keep the projects and notes from dissolving into chat logs and half-remembered intentions.

--- a/content/projects/repo-rails.md
+++ b/content/projects/repo-rails.md
@@ -15,25 +15,8 @@ live_url:
 docs_url: https://github.com/jjmgoss/repo-rails/tree/main/docs
 ---
 
-A standardized way of initializing a GitHub repo to support a new project, in a way that's friendly to
-the way I've landed on working with agents.
+This is the kit for bootstrapping a repo so the agent-heavy workflow has some rails to stay on.
 
-While getting the machines to code up hn-trends-tracker, it became clear that the only easy way
-to orchestrate agents is to instruct them to do things in a highly structured way. Unfortunately for
-them, I don't like doing things in a highly structured way, so I get another agent to intermediate. 
+While working on HN Trend Tracker, it became obvious that the hard part was not getting an agent to write code. The hard part was getting the repo, issues, prompts, and review loop into a shape that made the agents less likely to wander into the woods.
 
-I landed on telling them what to do using a GitHub-centric workflow that revolves around
-trying to keep some agent with high-level context doing most of the paperwork, passing off tasks to agents in
-Codex or the Copilot chat interface in VS Code, then getting my high-level confidante agent to review their code. 
-
-The workflow goes like this
-- I talk to an agent in a chat window. They pretend to understand my motivation, and will spit out very detailed
-prompts to the implementer agent, telling them what to do, in the form of a Github Issue.
-- I ask the confidante agent for a prompt telling the implementer agent where to find the issue, and instructions
-for implementing the issue.
-- The implementer agent pushes up a PR on a new branch of the repo, following some guidelines around PR formatting,
-describing what it's done.
-- The confidante agent reads the PR, reviews, and will tell me whether i should merge it.
-
-This repo-rails project is all in service of getting the initial repo set up to support this workflow when I set
-up a new project.
+So this project standardizes the paperwork: issue shapes, PR expectations, setup helpers, and the bits of repo structure that make that workflow less annoying to repeat.

--- a/content/site/home.md
+++ b/content/site/home.md
@@ -1,20 +1,20 @@
 ---
 eyebrow: Jason Goss
 headline: Making the machines work
-intro: I'm seeing what I can do with our newfound abilities to give machines vague instructions, and have them magically intuit our intent
+intro: A small lab for software contraptions, loose ends, and the occasional surprisingly useful result.
 primary_cta_label: View projects
 primary_cta_href: /projects
 secondary_cta_label: Read notes
 secondary_cta_href: /writing
-support: I hope these are actually useful, but they really only have to be a fun thing to have built
+support: If any of this turns out to be useful, even better.
 projects_section_eyebrow: Selected work
-projects_section_title: "Projects: Expect rough edges"
-projects_section_body: These are all in various states of disarray. That is the point.
+projects_section_title: Contraptions
+projects_section_body: The main catalog lives here. Rough edges included.
 projects_section_link_label: Browse the full project list
 projects_section_link_href: /projects
 notes_section_eyebrow: Notes
 notes_section_title: "Notes: What was I thinking?"
-notes_section_body: Things I noticed while trying to get the machines to do something useful.
+notes_section_body: Loose ends, false starts, and whatever seemed worth writing down before the next rabbit hole.
 latest_note_label: Latest note
 notes_section_link_label: Read all notes
 notes_section_link_href: /writing

--- a/content/site/notes.md
+++ b/content/site/notes.md
@@ -3,5 +3,5 @@ metadata_title: Notes
 metadata_description: Notes
 eyebrow: Loose ends
 headline: Notes from the workshop
-intro: Vague recollections of my motivations, and observations while making these things
+intro: Half-formed conclusions, workshop scraps, and the bits I wanted to remember before the next detour.
 ---

--- a/content/site/now.md
+++ b/content/site/now.md
@@ -3,25 +3,25 @@ metadata_title: Now
 metadata_description: "A current snapshot of projects, priorities, and work in progress."
 eyebrow: Now
 headline: "What we're focused on now"
-intro: "This is an agent-maintained snapshot of what we're working on."
-overview_title: What this is
-overview_body: "I can't possibly be bothered to keep up with all the goings-on, so I'm having the agents give it a go, to keep me up to speed."
+intro: "A quick operating snapshot of what currently has our attention."
+overview_title: How to read this
+overview_body: "This is the short version: what is active, what is public, and what is still being left alone on purpose."
 status_sections:
   - title: Current focus
-    body: "Right now the focus is sharpening the public presentation, clarifying project pages, tightening notes, and making the work easier to understand without turning the site into a product pitch."
+    body: "Right now the focus is on making the public-facing pieces cleaner, tighter, and less repetitive without sanding off the personality."
   - title: What exists now
-    body: "Projects, notes, and the current snapshot are already live in the app. The structure stays deliberately lightweight so adding work does not turn into maintaining a separate publishing system."
+    body: "The public site, the project pages, and the notes index are live. The structure stays intentionally lightweight so adding work does not become its own side project."
   - title: Deployment status
-    body: "The site runs in a LAN-first self-hosted setup today. Public routing has been planned, but it is still intentionally off while the content and presentation get stronger."
+    body: "The site is publicly reachable now, but the infrastructure details are still not the interesting part. The main job is making the work itself worth clicking on."
   - title: What is still intentionally private
-    body: "Internet-facing deployment, infrastructure details, and other operational mechanics are not the story yet. The goal is to make the work clearer first, then make it public."
+    body: "Operational details, home-network specifics, and the more boring mechanics are still staying out of the spotlight unless they are needed to explain the work."
   - title: Next milestones
-    body: "Next up is expanding project coverage, continuing to write down what is learned, and tightening the parts that make the work feel credible from the outside."
+    body: "Next up is expanding project coverage, writing down more of the useful bits, and tightening the places where the work still rambles."
 active_projects_title: Active projects
 active_projects_intro: "The few currently keeping me up at night."
 active_projects:
   - slug: personal-site
-    summary: "The portfolio and notes hub itself. Right now the work is tightening the public presentation so it feels stable enough to share without pretending it is finished."
+    summary: "The public front door. Right now the work is mostly about making it clearer, tighter, and less repetitive without pretending it is finished."
   - slug: autonomous-product-development
     summary: "An AI-assisted research and build workflow for evaluating small product ideas, documenting the reasoning, and deciding when a prototype is actually worth building."
   - slug: hn-trend-tracker

--- a/content/site/projects.md
+++ b/content/site/projects.md
@@ -3,5 +3,5 @@ metadata_title: Projects
 metadata_description: Work-in-progress software, automation, and AI experiments by Jason Goss.
 eyebrow: Contraptions
 headline: Projects in progress
-intro: Things I'm having the machines make. All are rough. All of them are real.
+intro: All are rough. All are real.
 ---

--- a/content/site/site.json
+++ b/content/site/site.json
@@ -1,10 +1,10 @@
 {
   "title": "Making the machines work",
   "metadataDescription": "Software projects, technical notes, and AI-assisted experiments by Jason Goss.",
-  "headerKicker": "Software projects and notes",
-  "headerSubtitle": "AI-assisted software experiments and project notes",
+  "headerKicker": "Contraptions",
+  "headerSubtitle": "Software experiments, workshop notes, and the bits that survived contact with reality.",
   "footerTitle": "Jason Goss",
-  "footerSummary": "Projects, notes, and experiments in software, automation, and agent workflows.",
+  "footerSummary": "Loose ends, source, and a way back out.",
   "primaryNav": [
     {
       "href": "/projects",


### PR DESCRIPTION
## Summary
- shorten the homepage so it teases projects and notes without repeating the full site framing
- reduce repeated header/footer and section-page copy while preserving the existing voice
- tighten project and now-page copy where it was repeating the same explanation

## Testing
- npm run validate:content
- npm run clean
- npm run build
- npm run test:site