### PR TITLE
[agent-task] Make Now page agent-maintained

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ git pull --ff-only origin main
 - `content/writing/*.md`: writing posts must include `author`. If `author: Jason Goss` or `author` is missing, treat the body as protected. Agent-authored posts may be edited within issue scope.
 - `content/site/home.md`, `content/site/projects.md`, `content/site/notes.md`, and `content/site/site.json`: Jason-owned site copy. Do not rewrite for polish, refactor, testing, deployment, or infrastructure tasks.
 - `content/site/now.md`: agent-maintained and public-safe. Update it when a PR changes public routes, project status or live URLs, deployment posture, active project list, or next priorities. Keep private infrastructure details, secrets, and local-only values out of it.
+- Agent-maintained public copy may be lightly droll and understated when the agent is the acknowledged author of a file or other copy, but must remain factual, useful, public-safe, and credibility-preserving. Prefer dry understatement over jokes. Never insult the human, the reader, or the work. Only do this sparingly, and only when it's clear that it is the agent speaking, not a human.
 - Human-written docs, code comments, and implementation choices outside the issue scope should also be preserved. Put non-essential rewrite suggestions in the PR body instead of applying them.
 
 ## Repository Boundaries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ git pull --ff-only origin main
 - `content/projects/*.md`: Jason owns project body copy. Do not rewrite project descriptions unless an issue explicitly asks for project copy edits. Only change factual frontmatter when the issue explicitly requires it.
 - `content/writing/*.md`: writing posts must include `author`. If `author: Jason Goss` or `author` is missing, treat the body as protected. Agent-authored posts may be edited within issue scope.
 - `content/site/home.md`, `content/site/projects.md`, `content/site/notes.md`, and `content/site/site.json`: Jason-owned site copy. Do not rewrite for polish, refactor, testing, deployment, or infrastructure tasks.
-- `content/site/now.md`: agent-maintained and public-safe. Keep updates factual and small unless issue #45 or another explicit issue asks for a larger rewrite.
+- `content/site/now.md`: agent-maintained and public-safe. Update it when a PR changes public routes, project status or live URLs, deployment posture, active project list, or next priorities. Keep private infrastructure details, secrets, and local-only values out of it.
 - Human-written docs, code comments, and implementation choices outside the issue scope should also be preserved. Put non-essential rewrite suggestions in the PR body instead of applying them.
 
 ## Repository Boundaries

--- a/app/now/page.tsx
+++ b/app/now/page.tsx
@@ -23,21 +23,30 @@ export default async function NowPage() {
       <p className="lede">{pageContent.intro}</p>
 
       <div className="stack-tight">
-        <h2>{pageContent.overview.title}</h2>
-        <p className="lede">{pageContent.overview.body}</p>
+        <h2>{pageContent.currentState.title}</h2>
+        <p className="lede">{pageContent.currentState.body}</p>
       </div>
 
-      <div className="project-list">
-        {pageContent.statusSections.map((section) => (
-          <article className="project-card" key={section.title}>
-            <div className="stack-tight">
-              <p className="status-pill">Current</p>
-              <h2>{section.title}</h2>
-            </div>
-            <p>{section.body}</p>
-          </article>
-        ))}
+      <div className="stack-tight">
+        <h2>{pageContent.liveRoutes.title}</h2>
+        <p className="lede">{pageContent.liveRoutes.intro}</p>
       </div>
+
+      <ul className="project-list">
+        {pageContent.liveRoutes.items.map((route) => (
+          <li className="project-card" key={route.href}>
+            <div className="stack-tight">
+              <p className="status-pill">Live</p>
+              <h2>
+                <a href={route.href} rel="noreferrer" target="_blank">
+                  {route.label}
+                </a>
+              </h2>
+            </div>
+            <p>{route.summary}</p>
+          </li>
+        ))}
+      </ul>
 
       <div className="stack-tight">
         <h2>{pageContent.activeProjects.title}</h2>
@@ -65,15 +74,45 @@ export default async function NowPage() {
       </ul>
 
       <div className="stack-tight">
-        <h2>{pageContent.explore.title}</h2>
-        <ul className="project-links">
-          {pageContent.explore.links.map((link) => (
-            <li key={link.href}>
-              <Link href={link.href}>{link.label}</Link>
-            </li>
-          ))}
-        </ul>
+        <h2>{pageContent.recentlyChanged.title}</h2>
       </div>
+
+      <ul className="project-list">
+        {pageContent.recentlyChanged.items.map((item) => (
+          <li className="project-card" key={item}>
+            <p>{item}</p>
+          </li>
+        ))}
+      </ul>
+
+      <div className="stack-tight">
+        <h2>{pageContent.nextLikelyWork.title}</h2>
+      </div>
+
+      <ul className="project-list">
+        {pageContent.nextLikelyWork.items.map((item) => (
+          <li className="project-card" key={item}>
+            <p>{item}</p>
+          </li>
+        ))}
+      </ul>
+
+      <div className="stack-tight">
+        <h2>{pageContent.whatStaysPrivate.title}</h2>
+        <p className="lede">{pageContent.whatStaysPrivate.body}</p>
+      </div>
+
+      <div className="stack-tight">
+        <h2>{pageContent.agentMaintenance.title}</h2>
+      </div>
+
+      <ul className="project-list">
+        {pageContent.agentMaintenance.items.map((item) => (
+          <li className="project-card" key={item}>
+            <p>{item}</p>
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/content/site/now.md
+++ b/content/site/now.md
@@ -3,43 +3,45 @@ metadata_title: Now
 metadata_description: "A current snapshot of projects, priorities, and work in progress."
 eyebrow: Now
 headline: "What we're focused on now"
-intro: "This is an agent-maintained snapshot of what we're working on."
-overview_title: What this is
-overview_body: "I can't possibly be bothered to keep up with all the goings-on, so I'm having the agents give it a go, to keep me up to speed."
-status_sections:
-  - title: Current focus
-    body: "Right now the focus is sharpening the public presentation, clarifying project pages, tightening notes, and making the work easier to understand without turning the site into a product pitch."
-  - title: What exists now
-    body: "Projects, notes, and the current snapshot are already live in the app. The structure stays deliberately lightweight so adding work does not turn into maintaining a separate publishing system."
-  - title: Deployment status
-    body: "The site is publicly reachable now. The setup is still intentionally simple while the content and project pages get tighter."
-  - title: What is still intentionally private
-    body: "Operational details and private infrastructure specifics are still not the story, so they stay out of the public copy unless they are needed to explain the work."
-  - title: Next milestones
-    body: "Next up is expanding project coverage, continuing to write down what is learned, and tightening the parts that make the work feel credible from the outside."
+intro: "An agent-maintained snapshot of what is live, what is active, and what is likely next."
+current_state_title: Current state
+current_state_body: "The personal site is the public project hub and notes surface. HN Trend Tracker is also publicly reachable. The work right now is mostly public polish, project-page clarity, deployment hygiene, and making the catalog more useful without turning it into a dashboard."
+live_routes_title: Live routes
+live_routes_intro: "The public endpoints worth knowing about right now."
+live_routes:
+  - label: Personal site
+    href: https://lab.jjmgoss.com
+    summary: "The main project hub and notes surface."
+  - label: HN Trend Tracker
+    href: https://hn.jjmgoss.com
+    summary: "Public, useful, and still visibly rough around the edges."
 active_projects_title: Active projects
-active_projects_intro: "The few currently keeping me up at night."
+active_projects_intro: "The projects currently getting the most attention."
 active_projects:
   - slug: personal-site
-    summary: "The portfolio and notes hub itself. Right now the work is tightening the public presentation so it feels stable enough to share without pretending it is finished."
+    summary: "The project hub itself. The current job is making the catalog, notes surface, and public presentation clearer and more credible."
   - slug: autonomous-product-development
-    summary: "An AI-assisted research and build workflow for evaluating small product ideas, documenting the reasoning, and deciding when a prototype is actually worth building."
+    summary: "Still early and more conceptual than polished, but it remains one of the active threads in the wider project set."
   - slug: hn-trend-tracker
-    summary: "A separate project exploring Hacker News trend collection, analysis, and presentation. It remains one of the active projects documented from this site."
+    summary: "Public now, still rough, and still the clearest example of a separate live app linked from this site."
   - slug: repo-rails
-    summary: "A tooling project for repo structure, policy, and review workflows that supports repeatable setup across project repositories."
-explore_title: Explore from here
-explore_links:
-  - href: /projects
-    label: Project catalog
-  - href: /projects/personal-site
-    label: Personal Site
-  - href: /projects/autonomous-product-development
-    label: Autonomous Product Development
-  - href: /projects/hn-trend-tracker
-    label: HN Trend Tracker
-  - href: /projects/repo-rails
-    label: repo-rails
-  - href: /writing
-    label: Notes
+    summary: "The repo setup and workflow toolkit that helps keep the agent-heavy project pattern repeatable."
+recently_changed_title: Recently changed
+recently_changed:
+  - "The personal site is live at https://lab.jjmgoss.com."
+  - "HN Trend Tracker is live at https://hn.jjmgoss.com and linked from the project catalog."
+  - "The site now has smoke tests, theme support, and tighter public-route verification."
+  - "Authorship and ownership rules now protect Jason-authored copy while keeping this page agent-maintained."
+next_likely_work_title: Next likely work
+next_likely_work:
+  - "Keep tightening public polish and project-page clarity."
+  - "Continue deployment hygiene and public-safe documentation around the live setup."
+  - "Expand project coverage and make the catalog more useful without turning the site into a product pitch."
+what_stays_private_title: What stays private
+what_stays_private_body: "Secrets, local network details, private hostnames, filesystem paths, and the more boring operational mechanics stay out of public copy unless they are needed for a public-safe explanation."
+agent_maintenance_title: Agent maintenance notes
+agent_maintenance:
+  - "Update this page when a PR changes public routes, live URLs, project status, deployment posture, active projects, or next priorities."
+  - "Keep it static, factual, and public-safe rather than turning it into a live status dashboard."
+  - "When in doubt, prefer small updates during normal project PRs and reserve larger restructures for explicit /now issues."
 ---

--- a/content/site/now.md
+++ b/content/site/now.md
@@ -5,43 +5,43 @@ eyebrow: Now
 headline: "What we're focused on now"
 intro: "An agent-maintained snapshot of what is live, what is active, and what is likely next."
 current_state_title: Current state
-current_state_body: "The personal site is the public project hub and notes surface. HN Trend Tracker is also publicly reachable. The work right now is mostly public polish, project-page clarity, deployment hygiene, and making the catalog more useful without turning it into a dashboard."
+current_state_body: "The personal site is live as the public hub and notes surface. HN Trend Tracker is also publicly reachable in its own right. Current attention is on public polish, project-page clarity, deployment hygiene, and making the catalog more useful without asking it to become a dashboard."
 live_routes_title: Live routes
-live_routes_intro: "The public endpoints worth knowing about right now."
+live_routes_intro: "The public endpoints currently permitted to represent themselves."
 live_routes:
   - label: Personal site
     href: https://lab.jjmgoss.com
-    summary: "The main project hub and notes surface."
+    summary: "The main project hub and notes surface, now expected to look presentable in company."
   - label: HN Trend Tracker
     href: https://hn.jjmgoss.com
-    summary: "Public, useful, and still visibly rough around the edges."
+    summary: "Public, useful, and still not making any extravagant claims about finish."
 active_projects_title: Active projects
-active_projects_intro: "The projects currently getting the most attention."
+active_projects_intro: "The projects currently receiving the most attention, whether they asked for it or not."
 active_projects:
   - slug: personal-site
-    summary: "The project hub itself. The current job is making the catalog, notes surface, and public presentation clearer and more credible."
+    summary: "The project hub itself. The present assignment is to make the catalog, notes surface, and public presentation clearer and a little less improvised."
   - slug: autonomous-product-development
-    summary: "Still early and more conceptual than polished, but it remains one of the active threads in the wider project set."
+    summary: "Still early and more conceptual than polished, but very much still on the books."
   - slug: hn-trend-tracker
-    summary: "Public now, still rough, and still the clearest example of a separate live app linked from this site."
+    summary: "Public now, still rough, and still the clearest example of a separate live app hanging off this site."
   - slug: repo-rails
-    summary: "The repo setup and workflow toolkit that helps keep the agent-heavy project pattern repeatable."
+    summary: "The repo setup and workflow toolkit responsible for making the agent-heavy project pattern repeatable on purpose."
 recently_changed_title: Recently changed
 recently_changed:
   - "The personal site is live at https://lab.jjmgoss.com."
-  - "HN Trend Tracker is live at https://hn.jjmgoss.com and linked from the project catalog."
-  - "The site now has smoke tests, theme support, and tighter public-route verification."
-  - "Authorship and ownership rules now protect Jason-authored copy while keeping this page agent-maintained."
+  - "HN Trend Tracker is live at https://hn.jjmgoss.com and linked from the project catalog, which is only fair."
+  - "The site now has smoke tests, theme support, and tighter public-route verification, so fewer surprises are reaching production unannounced."
+  - "Authorship and ownership rules now protect Jason-authored copy while leaving this page in the hands of the staff."
 next_likely_work_title: Next likely work
 next_likely_work:
   - "Keep tightening public polish and project-page clarity."
   - "Continue deployment hygiene and public-safe documentation around the live setup."
-  - "Expand project coverage and make the catalog more useful without turning the site into a product pitch."
+  - "Expand project coverage and make the catalog more useful without turning it into a product pitch or a filing cabinet."
 what_stays_private_title: What stays private
-what_stays_private_body: "Secrets, local network details, private hostnames, filesystem paths, and the more boring operational mechanics stay out of public copy unless they are needed for a public-safe explanation."
+what_stays_private_body: "Secrets, local network details, private hostnames, filesystem paths, and the less charming operational mechanics stay out of public copy unless a public-safe explanation genuinely requires them."
 agent_maintenance_title: Agent maintenance notes
 agent_maintenance:
   - "Update this page when a PR changes public routes, live URLs, project status, deployment posture, active projects, or next priorities."
-  - "Keep it static, factual, and public-safe rather than turning it into a live status dashboard."
+  - "Keep it static, factual, and public-safe rather than turning it into a live status dashboard with opinions about itself."
   - "When in doubt, prefer small updates during normal project PRs and reserve larger restructures for explicit /now issues."
 ---

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -45,6 +45,12 @@ Use `.github/PULL_REQUEST_TEMPLATE.md` to keep these sections consistent.
 - If a PR-caused check fails, fix it on the same branch and push again.
 - If a failure is unrelated or requires unavailable credentials, document that clearly in the PR.
 
+## Agent-Maintained Now Page
+
+When a PR materially changes public routes, project status, live URLs, deployment posture, the active project list, or the next likely priorities, update `content/site/now.md` as part of the same branch.
+
+Keep `/now` static, public-safe, and reviewable. Do not put secrets, private network details, local paths, or dashboard-style operational detail into that page.
+
 ## Review And Merge Posture
 
 - Do not merge without explicit human approval.

--- a/lib/content/site.ts
+++ b/lib/content/site.ts
@@ -56,14 +56,19 @@ export type NowContent = {
   eyebrow: string;
   headline: string;
   intro: string;
-  overview: {
+  currentState: {
     title: string;
     body: string;
   };
-  statusSections: Array<{
+  liveRoutes: {
     title: string;
-    body: string;
-  }>;
+    intro: string;
+    items: Array<{
+      label: string;
+      href: string;
+      summary: string;
+    }>;
+  };
   activeProjects: {
     title: string;
     intro: string;
@@ -72,9 +77,21 @@ export type NowContent = {
       summary: string;
     }>;
   };
-  explore: {
+  recentlyChanged: {
     title: string;
-    links: SiteLink[];
+    items: string[];
+  };
+  nextLikelyWork: {
+    title: string;
+    items: string[];
+  };
+  whatStaysPrivate: {
+    title: string;
+    body: string;
+  };
+  agentMaintenance: {
+    title: string;
+    items: string[];
   };
 };
 
@@ -92,6 +109,21 @@ function requireStringField(data: Record<string, unknown>, field: string, filePa
   }
 
   return value.trim();
+}
+
+function requireStringArrayField(data: Record<string, unknown>, field: string, filePath: string): string[] {
+  const value = data[field];
+
+  if (!Array.isArray(value) || value.some((item) => !isNonEmptyString(item))) {
+    throw new Error(`Invalid site content in ${filePath}: "${field}" must be a non-empty list of strings.`);
+  }
+
+  const trimmed = value.map((item) => item.trim());
+  if (trimmed.length === 0) {
+    throw new Error(`Invalid site content in ${filePath}: "${field}" must be a non-empty list of strings.`);
+  }
+
+  return trimmed;
 }
 
 function parseLink(value: unknown, filePath: string, field: string): SiteLink {
@@ -232,14 +264,19 @@ export const getNowContent = cache(async (): Promise<NowContent> => {
     eyebrow: requireStringField(data, 'eyebrow', filePath),
     headline: requireStringField(data, 'headline', filePath),
     intro: requireStringField(data, 'intro', filePath),
-    overview: {
-      title: requireStringField(data, 'overview_title', filePath),
-      body: requireStringField(data, 'overview_body', filePath),
+    currentState: {
+      title: requireStringField(data, 'current_state_title', filePath),
+      body: requireStringField(data, 'current_state_body', filePath),
     },
-    statusSections: parseStringArrayObjects(data.status_sections, filePath, 'status_sections', (item) => ({
-      title: requireStringField(item, 'title', filePath),
-      body: requireStringField(item, 'body', filePath),
-    })),
+    liveRoutes: {
+      title: requireStringField(data, 'live_routes_title', filePath),
+      intro: requireStringField(data, 'live_routes_intro', filePath),
+      items: parseStringArrayObjects(data.live_routes, filePath, 'live_routes', (item) => ({
+        label: requireStringField(item, 'label', filePath),
+        href: requireStringField(item, 'href', filePath),
+        summary: requireStringField(item, 'summary', filePath),
+      })),
+    },
     activeProjects: {
       title: requireStringField(data, 'active_projects_title', filePath),
       intro: requireStringField(data, 'active_projects_intro', filePath),
@@ -248,9 +285,21 @@ export const getNowContent = cache(async (): Promise<NowContent> => {
         summary: requireStringField(item, 'summary', filePath),
       })),
     },
-    explore: {
-      title: requireStringField(data, 'explore_title', filePath),
-      links: parseLinkArray(data.explore_links, filePath, 'explore_links'),
+    recentlyChanged: {
+      title: requireStringField(data, 'recently_changed_title', filePath),
+      items: requireStringArrayField(data, 'recently_changed', filePath),
+    },
+    nextLikelyWork: {
+      title: requireStringField(data, 'next_likely_work_title', filePath),
+      items: requireStringArrayField(data, 'next_likely_work', filePath),
+    },
+    whatStaysPrivate: {
+      title: requireStringField(data, 'what_stays_private_title', filePath),
+      body: requireStringField(data, 'what_stays_private_body', filePath),
+    },
+    agentMaintenance: {
+      title: requireStringField(data, 'agent_maintenance_title', filePath),
+      items: requireStringArrayField(data, 'agent_maintenance', filePath),
     },
   };
 });

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -433,20 +433,30 @@ async function validateSiteFiles(projectSlugs, writingSlugs, errors) {
         'eyebrow',
         'headline',
         'intro',
-        'overview_title',
-        'overview_body',
+        'current_state_title',
+        'current_state_body',
+        'live_routes_title',
+        'live_routes_intro',
         'active_projects_title',
         'active_projects_intro',
-        'explore_title',
+        'recently_changed_title',
+        'next_likely_work_title',
+        'what_stays_private_title',
+        'what_stays_private_body',
+        'agent_maintenance_title',
       ]) {
         requireStringField(data, field, fileName, errors, 'site');
       }
 
-      const statusSections = requireObjectArrayField(data, 'status_sections', fileName, errors, 'site');
-      statusSections.forEach((section, index) => {
-        requireStringField(section, 'title', fileName, errors, 'site');
-        requireStringField(section, 'body', fileName, errors, 'site');
-        requireObjectField(section, `status_sections[${index}]`, fileName, errors, 'site');
+      const liveRoutes = requireObjectArrayField(data, 'live_routes', fileName, errors, 'site');
+      liveRoutes.forEach((route, index) => {
+        requireStringField(route, 'label', fileName, errors, 'site');
+        requireStringField(route, 'summary', fileName, errors, 'site');
+        const href = requireStringField(route, 'href', fileName, errors, 'site');
+        requireObjectField(route, `live_routes[${index}]`, fileName, errors, 'site');
+        if (href) {
+          validateLinkTarget(href, filePath, `live_routes[${index}].href`, projectSlugs, writingSlugs, errors);
+        }
       });
 
       const activeProjects = requireObjectArrayField(data, 'active_projects', fileName, errors, 'site');
@@ -458,14 +468,9 @@ async function validateSiteFiles(projectSlugs, writingSlugs, errors) {
         }
       });
 
-      const exploreLinks = requireObjectArrayField(data, 'explore_links', fileName, errors, 'site');
-      exploreLinks.forEach((link, index) => {
-        requireStringField(link, 'label', fileName, errors, 'site');
-        const href = requireStringField(link, 'href', fileName, errors, 'site');
-        if (href) {
-          validateLinkTarget(href, filePath, `explore_links[${index}].href`, projectSlugs, writingSlugs, errors);
-        }
-      });
+      requireStringArrayField(data, 'recently_changed', fileName, errors, 'site');
+      requireStringArrayField(data, 'next_likely_work', fileName, errors, 'site');
+      requireStringArrayField(data, 'agent_maintenance', fileName, errors, 'site');
     }
 
     for (const target of extractInternalLinks(content)) {


### PR DESCRIPTION
## Summary
Turn `/now` into a clearer agent-maintained project/status snapshot while keeping it static, public-safe, and reviewable.

## Linked Issue Or Reference
Closes #45

## Authorship / Ownership
`content/site/now.md` is agent-maintained and was updated in this PR. Jason-owned site copy, project body copy, and Jason-authored notes were not rewritten.

## What Changed
- reworked the `now.md` content model into explicit current-state, live-routes, active-projects, recently-changed, next-likely-work, private-boundary, and agent-maintenance sections
- updated the `/now` parser, validation, and rendering to support the clearer structure cleanly
- added short agent-maintenance guidance for `/now` in `AGENTS.md` and workflow-level guidance in `docs/github-workflow.md`
- kept the page static/content-driven and limited the rendering changes to `/now`
- the final copy pass adjusted only the agent-maintained `/now` copy to better match the intended dry, understated agent voice

## Verification
- `npm run validate:content` — passed
- `npm run build` — passed
- `npm run test:site` — passed
- `git diff --stat` for the final copy pass — `content/site/now.md | 30` with 15 insertions and 15 deletions
- `git status` before the final commit showed only `content/site/now.md` modified
- `git status` after commit and push — clean
- no lint script exists in `package.json`
- manually verified `/now`, `/`, and `/projects`
- checked both light and dark mode during the manual pass

## Risk And Deployment Impact
Content/workflow only plus small `/now` rendering support. No Cloudflare, DNS, Docker, Synology, public-route, or deployment behavior changes.

## Reviewer Focus
- whether `/now` now answers what is live, active, recently changed, next, private, and expected of future agents
- whether the new schema and renderer stay clean and static rather than dashboard-like
- whether the final `/now` copy reads as lightly droll and orderly without losing usefulness or credibility

## Suggested Human Copy Edits
None.

## Follow-Ups
- keep updating `/now` during future PRs when public routes, live URLs, project status, deployment posture, active projects, or next priorities materially change