### PR TITLE
[agent-task] Display note author bylines

### DIFF
--- a/app/writing/[slug]/page.tsx
+++ b/app/writing/[slug]/page.tsx
@@ -46,7 +46,7 @@ export default async function WritingDetailPage({ params }: WritingDetailPagePro
       </Link>
       <p className="eyebrow">Notes</p>
       <div className="stack-tight">
-        <p className="post-date">{entry.date}</p>
+        <p className="post-date">By {entry.author} · {entry.date}</p>
         <h1>{entry.title}</h1>
       </div>
       <p className="lede">{entry.summary}</p>

--- a/app/writing/page.tsx
+++ b/app/writing/page.tsx
@@ -24,7 +24,7 @@ export default async function WritingPage() {
         {entries.map((entry) => (
           <li className="post-card" key={entry.slug}>
             <div className="stack-tight">
-              <p className="post-date">{entry.date}</p>
+              <p className="post-date">By {entry.author} · {entry.date}</p>
               <h2>
                 <Link href={`/writing/${entry.slug}`}>{entry.title}</Link>
               </h2>

--- a/lib/content/writing.ts
+++ b/lib/content/writing.ts
@@ -6,6 +6,7 @@ import { getProjectSlugs } from '@/lib/content/projects';
 export type WritingMetadata = {
   title: string;
   slug: string;
+  author: string;
   date: string;
   summary: string;
   tags: string[];
@@ -65,6 +66,7 @@ function requireDateField(data: Record<string, unknown>, field: string, filePath
 async function parseWritingMetadata(filePath: string, data: Record<string, unknown>): Promise<WritingMetadata> {
   const title = requireStringField(data, 'title', filePath);
   const slug = requireStringField(data, 'slug', filePath);
+  const author = requireStringField(data, 'author', filePath);
   const date = requireDateField(data, 'date', filePath);
   const summary = requireStringField(data, 'summary', filePath);
   const tags = requireStringArrayField(data, 'tags', filePath);
@@ -82,6 +84,7 @@ async function parseWritingMetadata(filePath: string, data: Record<string, unkno
   return {
     title,
     slug,
+    author,
     date,
     summary,
     tags,


### PR DESCRIPTION
## Summary
Render writing-post author metadata publicly on the notes index and note detail pages using the existing uthor frontmatter.

## Linked Issue Or Reference
Closes #59

## Authorship / Ownership
This PR renders existing writing author metadata only. Note body copy was not rewritten.

## What Changed
- exposed uthor through the writing content loader/types
- added a compact By {author} · {date} byline to each note card on /writing
- added the same compact byline near the title on /writing/[slug]

## Verification
- 
pm run validate:content — passed
- 
pm run build — passed
- 
pm run test:site — passed
- git diff --stat — 3 files changed, 5 insertions, 2 deletions
- git status — clean after commit and push
- no lint script exists in package.json
- manually verified /writing
- manually verified /writing/why-do-this
- confirmed the byline was visible without making either page feel cluttered

## Risk And Deployment Impact
Small public UI/content rendering change only. No Cloudflare, DNS, Docker, Synology, deployment, or routing changes.

## Reviewer Focus
- whether the byline reads clearly on both the index and detail page
- whether the author/date presentation feels understated and consistent with the existing notes styling
- whether the change stayed limited to rendering existing metadata rather than rewriting protected content

## Follow-Ups
- add more writing entries with varied uthor values as they exist so the public authorship model gets exercised more broadly