### PR TITLE
[agent-task] Add archival metadata affordance

### DIFF
--- a/app/ost/page.tsx
+++ b/app/ost/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Order of the Suspicious Timestamp',
+  description: 'A small archival note for readers who inspect chronology a little too closely.',
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function SuspiciousTimestampPage() {
+  return (
+    <section className="stack page-shell">
+      <p className="eyebrow">Archival Notice</p>
+      <h1>Order of the Suspicious Timestamp</h1>
+      <p className="lede">You noticed the archive is not entirely innocent.</p>
+      <div className="stack-tight markdown-body">
+        <p>This is unusual, and therefore has been recorded.</p>
+        <p>Badge awarded: Chronology Auditor, Third Class.</p>
+        <p>Please accept the staff&apos;s restrained concern and continue as you were.</p>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
Add a small unlinked archival route at /ost with understated copy and search-discouraging metadata.

## Linked Issue Or Reference
Closes #63

## Authorship / Ownership
Protected authored copy was not rewritten. Project descriptions, Jason-authored notes, visible site copy, navigation, footer links, and the existing writing pages were left intact.

## What Changed
- added a static /ost route using the existing site shell and styles
- set page metadata to emit 
oindex, nofollow
- kept the route unlinked from visible navigation and footer surfaces
- skipped the optional clue rather than adding a hacky visible or client-side artifact

## Verification
- 
pm run validate:content — passed
- 
pm run build — passed
- 
pm run test:site — passed
- git diff --stat — no output before staging because the change was a new untracked file
- git status before commit — showed only untracked pp/ost/
- no lint script exists in package.json
- manually verified /ost
- manually verified /writing
- manually verified /writing/why-do-this
- confirmed /ost is not in the visible nav or footer
- confirmed /ost emits 
oindex, nofollow

## Risk And Deployment Impact
Tiny public-safe UI/content change only. No deployment, infrastructure, routing behavior outside the new static route, or external service changes.

## Reviewer Focus
- whether the /ost page stays understated and harmless
- whether keeping it unlinked preserves the normal site experience
- whether the change remained isolated from protected authored content

## Follow-Ups
- none required unless future archival notes need a less hidden metadata convention