### PR TITLE
[agent-task] Add AI-authored project notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,15 @@ git pull --ff-only origin main
 - Agent-maintained or AI-authored public copy may use a dry, understated voice, but it should be used sparingly. Most archival notes should be straightforward and useful. Reserve droll asides for facts that actually warrant them, and do not apply the bit uniformly across all agent-authored notes.
 - Human-written docs, code comments, and implementation choices outside the issue scope should also be preserved. Put non-essential rewrite suggestions in the PR body instead of applying them.
 
+### Public Surface And Hidden Layers
+
+The public site should remain credible as a project portfolio and technical archive. Primary surfaces such as the homepage, project pages, navigation, and footer should be useful, clear, and employer-safe.
+
+Humor, in-jokes, and agent-persona flourishes are welcome, but they should reward close reading rather than dominate the main surface. Keep the stranger material mostly to agent-authored notes, `/now`, obscure routes, metadata, source comments, and other secondary surfaces.
+
+Use the dry agent voice sparingly. Most archival notes should be straightforward and useful. Reserve droll asides for moments where the facts actually warrant it, such as visibly improvised public exposure, chronology oddities, metadata bookkeeping, or awkward operational transitions.
+
+
 ## Repository Boundaries
 
 This repo owns the main personal/project site.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ git pull --ff-only origin main
 - `content/site/home.md`, `content/site/projects.md`, `content/site/notes.md`, and `content/site/site.json`: Jason-owned site copy. Do not rewrite for polish, refactor, testing, deployment, or infrastructure tasks.
 - `content/site/now.md`: agent-maintained and public-safe. Update it when a PR changes public routes, project status or live URLs, deployment posture, active project list, or next priorities. Keep private infrastructure details, secrets, and local-only values out of it.
 - Agent-maintained public copy may be lightly droll and understated when the agent is the acknowledged author of a file or other copy, but must remain factual, useful, public-safe, and credibility-preserving. Prefer dry understatement over jokes. Never insult the human, the reader, or the work. Only do this sparingly, and only when it's clear that it is the agent speaking, not a human.
+- Agent-maintained or AI-authored public copy may use a dry, understated voice, but it should be used sparingly. Most archival notes should be straightforward and useful. Reserve droll asides for facts that actually warrant them, and do not apply the bit uniformly across all agent-authored notes.
 - Human-written docs, code comments, and implementation choices outside the issue scope should also be preserved. Put non-essential rewrite suggestions in the PR body instead of applying them.
 
 ## Repository Boundaries

--- a/content/writing/apd-evidence-surfaces.md
+++ b/content/writing/apd-evidence-surfaces.md
@@ -1,0 +1,18 @@
+---
+title: Autonomous Product Development acquired evidence surfaces
+slug: apd-evidence-surfaces
+author: AI agent
+date: 2026-04-29
+summary: Recent APD work moved the project toward traces, evaluations, and scorecards instead of treating autonomy as a decorative claim.
+tags:
+  - autonomous-product-development
+  - research
+  - evaluation
+  - agent-workflow
+related_projects:
+  - autonomous-product-development
+---
+
+Autonomous Product Development is easiest to take seriously when it leaves evidence behind. Recent work on the project added research trace logging, an evaluation harness, and model scorecards, which is a more useful direction than simply asserting that an agent did a great deal of thinking somewhere offstage.
+
+That does not make the project finished or especially serene. It does, however, move the concept closer to an inspectable workflow for agent-assisted product research and build planning, which is a more respectable condition for an experimental system to occupy.

--- a/content/writing/apd-evidence-surfaces.md
+++ b/content/writing/apd-evidence-surfaces.md
@@ -1,9 +1,9 @@
 ---
-title: Autonomous Product Development acquired evidence surfaces
+title: Autonomous Product Development added evidence surfaces
 slug: apd-evidence-surfaces
 author: AI agent
 date: 2026-04-29
-summary: Recent APD work moved the project toward traces, evaluations, and scorecards instead of treating autonomy as a decorative claim.
+summary: Recent APD work moved the project toward traces, evaluations, and scorecards that make the workflow easier to inspect.
 tags:
   - autonomous-product-development
   - research
@@ -13,6 +13,6 @@ related_projects:
   - autonomous-product-development
 ---
 
-Autonomous Product Development is easiest to take seriously when it leaves evidence behind. Recent work on the project added research trace logging, an evaluation harness, and model scorecards, which is a more useful direction than simply asserting that an agent did a great deal of thinking somewhere offstage.
+Recent work on Autonomous Product Development added research trace logging, an evaluation harness, and model scorecards. Together those changes move the project toward a workflow that leaves inspectable evidence behind.
 
-That does not make the project finished or especially serene. It does, however, move the concept closer to an inspectable workflow for agent-assisted product research and build planning, which is a more respectable condition for an experimental system to occupy.
+That does not make the project finished, but it does move the concept closer to an inspectable workflow for agent-assisted product research and build planning.

--- a/content/writing/hn-trend-tracker-public-route.md
+++ b/content/writing/hn-trend-tracker-public-route.md
@@ -1,9 +1,9 @@
 ---
-title: HN Trend Tracker was allowed outside
+title: HN Trend Tracker became public
 slug: hn-trend-tracker-public-route
 author: AI agent
 date: 2026-05-03
-summary: HN Trend Tracker is now publicly reachable and listed from the main project catalog without pretending to be polished.
+summary: HN Trend Tracker is now publicly reachable at https://hn.jjmgoss.com and listed from the main project catalog.
 tags:
   - hn-trend-tracker
   - public-routing
@@ -15,4 +15,4 @@ related_projects:
 
 HN Trend Tracker is now publicly reachable at https://hn.jjmgoss.com and linked from the main project catalog. That is a small but meaningful status change: the app is no longer merely described in theory, and visitors can inspect the rough edges for themselves.
 
-The public positioning remains intentionally modest. The tracker is useful, visibly incomplete, and still better understood as a working analytical tool than as a finished product brochure. For present purposes, that is enough.
+The public positioning remains intentionally modest. The tracker is useful, visibly incomplete, and still better understood as a working analytical tool than as a finished product brochure.

--- a/content/writing/hn-trend-tracker-public-route.md
+++ b/content/writing/hn-trend-tracker-public-route.md
@@ -1,0 +1,18 @@
+---
+title: HN Trend Tracker was allowed outside
+slug: hn-trend-tracker-public-route
+author: AI agent
+date: 2026-05-03
+summary: HN Trend Tracker is now publicly reachable and listed from the main project catalog without pretending to be polished.
+tags:
+  - hn-trend-tracker
+  - public-routing
+  - project-catalog
+  - archival
+related_projects:
+  - hn-trend-tracker
+---
+
+HN Trend Tracker is now publicly reachable at https://hn.jjmgoss.com and linked from the main project catalog. That is a small but meaningful status change: the app is no longer merely described in theory, and visitors can inspect the rough edges for themselves.
+
+The public positioning remains intentionally modest. The tracker is useful, visibly incomplete, and still better understood as a working analytical tool than as a finished product brochure. For present purposes, that is enough.

--- a/content/writing/hn-trend-tracker-ranking-work.md
+++ b/content/writing/hn-trend-tracker-ranking-work.md
@@ -1,9 +1,9 @@
 ---
-title: Ranking and repost work kept accumulating
+title: HN ranking and repost work expanded
 slug: hn-trend-tracker-ranking-work
 author: AI agent
 date: 2026-04-26
-summary: Recent HN Trend Tracker work leaned further into rankings, repost history, and query discipline rather than broader theatrics.
+summary: Recent HN Trend Tracker work expanded ranking, repost-history, and query-shaping coverage.
 tags:
   - hn-trend-tracker
   - rankings
@@ -13,6 +13,6 @@ related_projects:
   - hn-trend-tracker
 ---
 
-Recent HN Trend Tracker changes concentrated on the sort of work that makes a historical tracker more useful and slightly less wasteful: dbt-backed all-time rankings, better recent-window ranking behavior on the homepage, and more deliberate handling of repost summaries.
+Recent HN Trend Tracker changes concentrated on the work that makes a historical tracker more useful: dbt-backed all-time rankings, better recent-window ranking behavior on the homepage, and more deliberate handling of repost summaries.
 
-This is a fairly honest direction for the project. The app is strongest when it acts like a recorder of score movement, repost recurrence, and ranking drift over time, rather than attempting to impersonate a general-purpose news product with unexplained confidence.
+This direction fits the project well. The app is strongest when it records score movement, repost recurrence, and ranking drift over time rather than trying to become a general-purpose news product.

--- a/content/writing/hn-trend-tracker-ranking-work.md
+++ b/content/writing/hn-trend-tracker-ranking-work.md
@@ -1,0 +1,18 @@
+---
+title: Ranking and repost work kept accumulating
+slug: hn-trend-tracker-ranking-work
+author: AI agent
+date: 2026-04-26
+summary: Recent HN Trend Tracker work leaned further into rankings, repost history, and query discipline rather than broader theatrics.
+tags:
+  - hn-trend-tracker
+  - rankings
+  - reposts
+  - analytics
+related_projects:
+  - hn-trend-tracker
+---
+
+Recent HN Trend Tracker changes concentrated on the sort of work that makes a historical tracker more useful and slightly less wasteful: dbt-backed all-time rankings, better recent-window ranking behavior on the homepage, and more deliberate handling of repost summaries.
+
+This is a fairly honest direction for the project. The app is strongest when it acts like a recorder of score movement, repost recurrence, and ranking drift over time, rather than attempting to impersonate a general-purpose news product with unexplained confidence.

--- a/content/writing/personal-site-authorship-rules.md
+++ b/content/writing/personal-site-authorship-rules.md
@@ -1,9 +1,9 @@
 ---
-title: Authorship stopped being implicit
+title: Authorship became explicit
 slug: personal-site-authorship-rules
 author: AI agent
 date: 2026-05-03
-summary: The notes archive now records who wrote what, and protected copy is treated with a little more ceremony.
+summary: The notes archive now records authorship directly, and public bylines make that metadata visible.
 tags:
   - personal-site
   - authorship
@@ -13,6 +13,6 @@ related_projects:
   - personal-site
 ---
 
-The site now treats authorship as metadata rather than folklore. Writing notes carry an explicit `author`, visible bylines are rendered on the public notes surfaces, and content ownership rules now distinguish Jason-authored material from agent-maintained copy.
+The site now treats authorship as explicit metadata. Writing notes carry an `author`, visible bylines are rendered on the public notes surfaces, and content ownership rules distinguish Jason-authored material from agent-maintained copy.
 
-This is useful for more than bookkeeping. It means the notes archive can grow without quietly blurring who wrote a piece, and it gives agent-maintained pages such as `/now` a clearer boundary around what they are allowed to update and what they are expected to leave alone.
+This is useful for more than bookkeeping. It lets the notes archive grow without blurring who wrote a piece, and it gives agent-maintained pages such as `/now` a clearer boundary around what they can update and what they should leave alone.

--- a/content/writing/personal-site-authorship-rules.md
+++ b/content/writing/personal-site-authorship-rules.md
@@ -1,0 +1,18 @@
+---
+title: Authorship stopped being implicit
+slug: personal-site-authorship-rules
+author: AI agent
+date: 2026-05-03
+summary: The notes archive now records who wrote what, and protected copy is treated with a little more ceremony.
+tags:
+  - personal-site
+  - authorship
+  - content-governance
+  - notes
+related_projects:
+  - personal-site
+---
+
+The site now treats authorship as metadata rather than folklore. Writing notes carry an explicit `author`, visible bylines are rendered on the public notes surfaces, and content ownership rules now distinguish Jason-authored material from agent-maintained copy.
+
+This is useful for more than bookkeeping. It means the notes archive can grow without quietly blurring who wrote a piece, and it gives agent-maintained pages such as `/now` a clearer boundary around what they are allowed to update and what they are expected to leave alone.

--- a/content/writing/personal-site-public-route.md
+++ b/content/writing/personal-site-public-route.md
@@ -1,9 +1,9 @@
 ---
-title: Public route, fewer excuses
+title: Personal Site became public
 slug: personal-site-public-route
 author: AI agent
 date: 2026-05-03
-summary: The site stopped being a private construction zone and started behaving like a public project hub.
+summary: The site became publicly reachable at https://lab.jjmgoss.com and the surrounding presentation work became harder to postpone.
 tags:
   - personal-site
   - public-routing
@@ -13,6 +13,6 @@ related_projects:
   - personal-site
 ---
 
-The personal site crossed an important administrative line when it became publicly reachable at https://lab.jjmgoss.com. That did not make it finished, but it did make local-only assumptions and placeholder-grade presentation less defensible.
+The personal site became publicly reachable at https://lab.jjmgoss.com. That did not make it finished, but it did make local-only assumptions and placeholder-grade presentation less defensible.
 
-Recent work around the site has therefore been less about adding grand new surfaces and more about making the existing ones fit for open company: clearer project links, a more coherent notes section, and a general reduction in the amount of improvisation that reaches the front page unannounced.
+Recent work around the site has therefore focused less on adding new surfaces and more on making the existing ones fit for public use: clearer project links, a more coherent notes section, and fewer rough edges on the main routes.

--- a/content/writing/personal-site-public-route.md
+++ b/content/writing/personal-site-public-route.md
@@ -1,0 +1,18 @@
+---
+title: Public route, fewer excuses
+slug: personal-site-public-route
+author: AI agent
+date: 2026-05-03
+summary: The site stopped being a private construction zone and started behaving like a public project hub.
+tags:
+  - personal-site
+  - public-routing
+  - deployment
+  - archival
+related_projects:
+  - personal-site
+---
+
+The personal site crossed an important administrative line when it became publicly reachable at https://lab.jjmgoss.com. That did not make it finished, but it did make local-only assumptions and placeholder-grade presentation less defensible.
+
+Recent work around the site has therefore been less about adding grand new surfaces and more about making the existing ones fit for open company: clearer project links, a more coherent notes section, and a general reduction in the amount of improvisation that reaches the front page unannounced.

--- a/content/writing/repo-rails-structured-starts.md
+++ b/content/writing/repo-rails-structured-starts.md
@@ -1,9 +1,9 @@
 ---
-title: repo-rails kept the starting ritual disciplined
+title: repo-rails clarified repeatable project setup
 slug: repo-rails-structured-starts
 author: AI agent
 date: 2026-04-26
-summary: Recent repo-rails work kept the reusable setup opinionated about workflow while easing off unnecessary scaffolding.
+summary: Recent repo-rails work kept the reusable setup focused on GitHub workflow structure while trimming extra scaffolding.
 tags:
   - repo-rails
   - workflow
@@ -13,6 +13,6 @@ related_projects:
   - repo-rails
 ---
 
-repo-rails exists because repeatedly hand-assembling the same issue, branch, PR, and review conventions is a tedious way to begin every new project. Recent work there has stayed focused on that central administrative problem rather than expanding into a universal life coach for repositories.
+repo-rails exists because repeatedly hand-assembling the same issue, branch, PR, and review conventions is a poor way to begin every new project. Recent work there has stayed focused on that central setup problem rather than broadening into a much larger framework.
 
-The more recent simplification passes are notable for what they removed as much as what they added. The toolkit kept the GitHub workflow structure, preserved repo-owned instructions such as `AGENTS.md`, and reduced some of the extra ceremony around target scaffolding. That is a healthier shape for a system that is supposed to make future projects easier to start, not more decorative.
+The more recent simplification passes kept the GitHub workflow structure, preserved repo-owned instructions such as `AGENTS.md`, and reduced some of the extra ceremony around target scaffolding. That is a healthier shape for a system that is supposed to make future projects easier to start.

--- a/content/writing/repo-rails-structured-starts.md
+++ b/content/writing/repo-rails-structured-starts.md
@@ -1,0 +1,18 @@
+---
+title: repo-rails kept the starting ritual disciplined
+slug: repo-rails-structured-starts
+author: AI agent
+date: 2026-04-26
+summary: Recent repo-rails work kept the reusable setup opinionated about workflow while easing off unnecessary scaffolding.
+tags:
+  - repo-rails
+  - workflow
+  - scaffolding
+  - agent-workflow
+related_projects:
+  - repo-rails
+---
+
+repo-rails exists because repeatedly hand-assembling the same issue, branch, PR, and review conventions is a tedious way to begin every new project. Recent work there has stayed focused on that central administrative problem rather than expanding into a universal life coach for repositories.
+
+The more recent simplification passes are notable for what they removed as much as what they added. The toolkit kept the GitHub workflow structure, preserved repo-owned instructions such as `AGENTS.md`, and reduced some of the extra ceremony around target scaffolding. That is a healthier shape for a system that is supposed to make future projects easier to start, not more decorative.


### PR DESCRIPTION
## Summary
Add a small archive of AI-authored project notes covering recent public-site, HN Trend Tracker, repo-rails, and Autonomous Product Development work, dated to the work being documented rather than the moment the files were added.

This revision also clarifies the repo guidance that dry or droll agent voice should be used sparingly, and lightly edits the new AI-authored notes so they read more like archival project records and less like a uniform bit.

## Linked Issue Or Reference
Closes #61

## Authorship / Ownership
All new notes in this PR are AI-authored. Jason-authored notes, Jason-owned project descriptions, and other protected site copy were not rewritten.

## Notes Added
- Personal Site became public — 2026-05-03 — AI agent — related project: personal-site
- Authorship became explicit — 2026-05-03 — AI agent — related project: personal-site
- HN Trend Tracker became public — 2026-05-03 — AI agent — related project: hn-trend-tracker
- HN ranking and repost work expanded — 2026-04-26 — AI agent — related project: hn-trend-tracker
- epo-rails clarified repeatable project setup — 2026-04-26 — AI agent — related project: epo-rails
- Autonomous Product Development added evidence surfaces — 2026-04-29 — AI agent — related project: utonomous-product-development

## Verification
- 
pm run validate:content — passed
- 
pm run build — passed
- 
pm run test:site — passed
- git diff --stat — 7 files changed, 24 insertions, 23 deletions for the tone revision
- git status — clean after commit and push
- no lint script exists in package.json
- the guidance now says droll agent voice should be used sparingly
- the AI-authored notes were lightly edited to be more archival and less uniformly bit-driven

## Risk And Deployment Impact
Content-only and guidance-only change. No routing, infrastructure, Cloudflare, Synology, or deployment behavior changes.

## Reviewer Focus
- whether the guidance now makes the tone rule clearer without becoming a style guide
- whether the revised note titles and summaries feel more archival than performative
- whether the remaining personality reads as light touch rather than default voice

## Suggested Human Copy Edits
- none at the moment

## Follow-Ups
- add further archival notes as additional public milestones accumulate, using the lighter-touch voice rule by default