### PR TITLE
[agent-task] Remove private-boundary section from Now page

### DIFF
--- a/app/now/page.tsx
+++ b/app/now/page.tsx
@@ -98,11 +98,6 @@ export default async function NowPage() {
       </ul>
 
       <div className="stack-tight">
-        <h2>{pageContent.whatStaysPrivate.title}</h2>
-        <p className="lede">{pageContent.whatStaysPrivate.body}</p>
-      </div>
-
-      <div className="stack-tight">
         <h2>{pageContent.agentMaintenance.title}</h2>
       </div>
 

--- a/content/site/now.md
+++ b/content/site/now.md
@@ -37,8 +37,6 @@ next_likely_work:
   - "Keep tightening public polish and project-page clarity."
   - "Continue deployment hygiene and public-safe documentation around the live setup."
   - "Expand project coverage and make the catalog more useful without turning it into a product pitch or a filing cabinet."
-what_stays_private_title: What stays private
-what_stays_private_body: "Secrets, local network details, private hostnames, filesystem paths, and the less charming operational mechanics stay out of public copy unless a public-safe explanation genuinely requires them."
 agent_maintenance_title: Agent maintenance notes
 agent_maintenance:
   - "Update this page when a PR changes public routes, live URLs, project status, deployment posture, active projects, or next priorities."

--- a/lib/content/site.ts
+++ b/lib/content/site.ts
@@ -85,10 +85,6 @@ export type NowContent = {
     title: string;
     items: string[];
   };
-  whatStaysPrivate: {
-    title: string;
-    body: string;
-  };
   agentMaintenance: {
     title: string;
     items: string[];
@@ -292,10 +288,6 @@ export const getNowContent = cache(async (): Promise<NowContent> => {
     nextLikelyWork: {
       title: requireStringField(data, 'next_likely_work_title', filePath),
       items: requireStringArrayField(data, 'next_likely_work', filePath),
-    },
-    whatStaysPrivate: {
-      title: requireStringField(data, 'what_stays_private_title', filePath),
-      body: requireStringField(data, 'what_stays_private_body', filePath),
     },
     agentMaintenance: {
       title: requireStringField(data, 'agent_maintenance_title', filePath),

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -441,8 +441,6 @@ async function validateSiteFiles(projectSlugs, writingSlugs, errors) {
         'active_projects_intro',
         'recently_changed_title',
         'next_likely_work_title',
-        'what_stays_private_title',
-        'what_stays_private_body',
         'agent_maintenance_title',
       ]) {
         requireStringField(data, field, fileName, errors, 'site');


### PR DESCRIPTION
## Summary
Remove the public-facing private-boundary section from /now while keeping the page public-safe and leaving internal safety guidance in agent docs.

## Linked Issue Or Reference
Closes #68

## What Changed
- removed the What stays private section from content/site/now.md
- removed the related Now-page content model wiring from the site loader and renderer
- updated content validation so the removed public fields are no longer required

## Verification
- 
pm run validate:content — passed
- 
pm run build — passed
- 
pm run test:site — passed
- manual verification of /now — passed
- no lint script exists in package.json

## Risk And Deployment Impact
Small public content/schema cleanup only. No Cloudflare, DNS, Docker, Synology, deployment, or routing behavior changes.

## Reviewer Focus
- confirm the public What stays private section is fully removed
- confirm the rest of /now still reads cleanly and remains public-safe
- confirm internal safety guidance remains in docs rather than public copy