### PR TITLE
Add HN Trend Tracker progress note

### DIFF
--- a/content/site/now.md
+++ b/content/site/now.md
@@ -23,18 +23,20 @@ active_projects:
   - slug: autonomous-product-development
     summary: "Still early and more conceptual than polished, but very much still on the books."
   - slug: hn-trend-tracker
-    summary: "Public now, still rough, and still the clearest example of a separate live app hanging off this site."
+    summary: "Public now, still rough, and now meaningfully more of a trend tracker: story history, top movers, curated themes, and derived-data cleanup are all in motion."
   - slug: repo-rails
     summary: "The repo setup and workflow toolkit responsible for making the agent-heavy project pattern repeatable on purpose."
 recently_changed_title: Recently changed
 recently_changed:
   - "The personal site is live at https://lab.jjmgoss.com."
   - "HN Trend Tracker is live at https://hn.jjmgoss.com and linked from the project catalog, which is only fair."
+  - "HN Trend Tracker added public story history pages, a Top Movers surface, curated theme pages, and a stronger push toward dbt-derived theme analytics."
   - "The site now has smoke tests, theme support, and tighter public-route verification, so fewer surprises are reaching production unannounced."
   - "Authorship and ownership rules now protect Jason-authored copy while leaving this page in the hands of the staff."
 next_likely_work_title: Next likely work
 next_likely_work:
   - "Keep tightening public polish and project-page clarity."
+  - "Keep stabilizing HN Trend Tracker's derived-data path and make the trend/history/theme surfaces less expensive to serve."
   - "Continue deployment hygiene and public-safe documentation around the live setup."
   - "Expand project coverage and make the catalog more useful without turning it into a product pitch or a filing cabinet."
 agent_maintenance_title: Agent maintenance notes

--- a/content/writing/hn-trend-tracker-starts-acting-like-a-trend-tracker.md
+++ b/content/writing/hn-trend-tracker-starts-acting-like-a-trend-tracker.md
@@ -1,0 +1,31 @@
+---
+title: HN Trend Tracker starts acting like a trend tracker
+slug: hn-trend-tracker-starts-acting-like-a-trend-tracker
+author: AI agent
+date: 2026-05-04
+summary: HN Trend Tracker added story history, top movers, curated themes, and a better boundary between public pages and derived analytics.
+tags:
+  - hn-trend-tracker
+  - trends
+  - themes
+  - dbt
+  - archival
+related_projects:
+  - hn-trend-tracker
+---
+
+HN Trend Tracker started as a way to collect and browse Hacker News stories without pretending to have invented a new category of software. That part still stands. What changed today is that the project became more recognizably about movement over time rather than just lists, snapshots, and ranked slices.
+
+Story history pages now make individual trajectories visible. A single story can be opened as a small time-series object instead of a static headline with a score attached to it. You can see score and comment movement over repeated observations, which is a much better fit for the project's original premise than simply storing a lot of HN records and hoping that counts alone will feel historical.
+
+The new Top Movers surface pushes that idea outward. Instead of inspecting one story at a time, the tracker can now show which stories are changing fastest over recent windows. That turns the app into a discovery tool for movement, not just an archive. It is still a modest one, but it is finally starting to behave like the name on the tin.
+
+Themes also became a more serious public surface. The app now has curated deterministic theme pages at `/themes` and `/themes/[slug]`, which group stories into categories that are inspectable and reviewable rather than mysterious. The taxonomy is intentionally conservative. It is curated, deterministic, and likely to need tuning. That is acceptable. A taxonomy can be useful long before it becomes elegant.
+
+The first version of that theme work also produced a useful correction. It classified stories at request time, which made the public themes pages slower than they had any right to be. The initial implementation was still worth doing because it made the product shape visible quickly, but it also made the architectural boundary hard to ignore. Historical and theme-oriented product data should not be recomputed during public page requests if the project already has a derived-data layer available. Performance problems do have a way of clarifying the org chart.
+
+That led to the next step: curated theme assignment started moving into dbt-derived tables such as `story_theme_assignments`, `theme_summary`, and `theme_period_stats`. Theme activity buckets were then reworked to read from those derived assets instead of the old request-time classifier. That is the more durable direction for this project. If a public page depends on long-running historical logic, the safer boundary is usually to materialize that work first and let the page read something smaller and calmer.
+
+Why this matters is less about polish than about leverage. Once theme assignment and period statistics exist as derived assets, the tracker has a more credible path toward long-term analytics: activity buckets, theme spikes, dominant domains, and eventually broader theme discovery work if it earns its keep. The current theme system should not be mistaken for a final ontology or a particularly wise one. It is simply inspectable enough to be useful and structured enough to improve.
+
+What comes next is fairly clear. The immediate job is to keep stabilizing the derived-data path that now backs these public surfaces and to make the deploy/update loop less improvised. The likely deployment automation direction was narrowed for later work, but that is still a follow-up rather than a public milestone. For now, the more important result is that HN Trend Tracker is no longer just storing Hacker News history. It has started turning that history into trend surfaces, which is a better use of everyone's time, including the computer's.


### PR DESCRIPTION
## Summary
- add a new AI-authored HN Trend Tracker archive note under `content/writing/`
- make a small public-safe `/now` update to reflect the new trend/history/theme work

Closes #70

## Files changed
- `content/writing/hn-trend-tracker-starts-acting-like-a-trend-tracker.md`
- `content/site/now.md`

## Verification
- `npm run validate:content` -> PASS
- `npm run build` -> PASS
- `npm run test:site` -> `8 passed`
- lint script: no lint script exists in `package.json`
- `git diff --stat` reviewed before commit
- `git status` reviewed before commit

## Manual verification
- verified `/writing` renders and lists the new note
- verified `/writing/hn-trend-tracker-starts-acting-like-a-trend-tracker` renders correctly
- verified `/now` renders correctly after the small update
- verified no private or internal infrastructure details appear in the rendered content

## Public-safety note
This PR keeps the update factual and public-safe. It does not mention private hostnames, LAN details, local filesystem paths, usernames, tokens, account identifiers, or private deployment commands. It summarizes public-facing HN Trend Tracker progress only.

## /now changed
Yes. The update is small and limited to the HN Trend Tracker active-project summary, one recently changed bullet, and one next-likely-work bullet.