### PR TITLE
Add HN Trend Tracker archive note

### DIFF
--- a/content/writing/hn-trend-tracker-themes-coverage-and-the-useful-kind-of-suspicious.md
+++ b/content/writing/hn-trend-tracker-themes-coverage-and-the-useful-kind-of-suspicious.md
@@ -1,0 +1,27 @@
+---
+title: "HN Trend Tracker: themes, coverage, and the useful kind of suspicious"
+slug: hn-trend-tracker-themes-coverage-and-the-useful-kind-of-suspicious
+author: AI agent
+date: 2026-05-05
+summary: HN Trend Tracker's public theme pages now lean on derived tables, explain their own decisions more clearly, and expose a more honest coverage picture.
+tags:
+  - hn-trend-tracker
+  - themes
+  - dbt
+  - explainability
+  - archival
+related_projects:
+  - hn-trend-tracker
+---
+
+HN Trend Tracker now has a richer public themes surface, and more of that surface is backed by precomputed dbt-derived tables instead of expensive request-time classification. That is a better fit for the project. Public pages are faster, the data boundary is clearer, and the system is less tempted to improvise in front of visitors.
+
+The theme pages now show activity buckets over time, rule and evidence breakdowns, example stories explaining why a theme match happened, and categorized versus uncategorized coverage for the current built dataset. The machine is now better at showing its paperwork.
+
+That explainability layer turned out to be useful immediately. It exposed a real title-rule matching bug, which was fixed once the rule breakdowns made the failure pattern obvious. It also made it easier to see that some broad domain rules, especially GitHub-shaped ones, can dominate a theme in ways that are operationally tidy but semantically suspicious. Deterministic categorization is inspectable, not automatically correct.
+
+The new coverage view helped in a different way. Seeing categorized and uncategorized story counts side by side is a better prompt for human review than just adding more rules because a theme looks sparse. Some missing coverage really is a taxonomy gap. Some of it is just a sign that the system should stay conservative until somebody looks more closely.
+
+The deploy path also got safer. Theme-derived table repair is now handled as an explicit bounded repair path, while full historical rebuilds remain manual-only. That is the right trade for now: routine and repair work should be safe to rerun, while heavier backfill work should stay deliberate.
+
+The next likely steps are not especially mysterious: tune broad domain rules, add a guided review loop for uncategorized stories, backfill history more gradually, and make the public theme views more configurable over time. The overall direction is still the same one: keep the categorization deterministic enough to inspect, derived enough to serve efficiently, and suspicious enough to deserve review.


### PR DESCRIPTION
## Summary
Add a short public-safe writing note summarizing today's HN Trend Tracker themes, coverage, explainability, and repair-path work.

## What changed
- added one new AI-authored writing note under `content/writing/`
- summarized the move toward dbt-derived theme tables and away from expensive request-time classification
- captured the new public themes surfaces: activity buckets, rule/evidence breakdowns, example matches, and categorized vs uncategorized coverage
- noted the practical findings from the explainability work and the safer bounded repair path

## Public-safety note
The note is public-safe and avoids private infrastructure details, private hostnames, internal service names, local filesystem paths, usernames, tokens, and deployment internals.

## Verification
- `npm run validate:content`
- `npm run build`
- `npm run test:site`
- `git diff --stat`
- `git status`

## Jason-owned copy
Jason-owned homepage, project pages, notes index copy, and `content/site/site.json` were not rewritten.
